### PR TITLE
[CM-739] iOS SDK | RTL support for sign-in page and text bar in chat page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 
 
 ## [Unreleased]
-
+- Fixed the Chat bar RTL support issue
 - Added support for text areas in rich message forms
 - Send Post Submitted Form Data As Message
 - Added Support for RTL Languages

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'
   s.author = { 'Mukesh Thawani' => 'mukesh@applozic.com' }
 
-  s.source = { :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :tag => s.version }
+  s.source = { :git => 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git', :tag => s.version }
 
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.0'

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'
   s.author = { 'Mukesh Thawani' => 'mukesh@applozic.com' }
 
-  s.source = { :git => 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK.git', :tag => s.version }
+  s.source = { :git => 'https://github.com/Sathyan-Elangovan/KommunicateChatUI-iOS-SDK.git', :tag => s.version }
 
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.0'

--- a/Sources/Utilities/UI+Style.swift
+++ b/Sources/Utilities/UI+Style.swift
@@ -78,6 +78,13 @@ extension UITextView {
         let isRTL = NSLocale.characterDirection(forLanguage: language) == .rightToLeft
         textAlignment = isRTL ? .right : .left
     }
+    //For ALK ChatBar Place Holder
+    func changePlaceHolderDirection(){
+        let language = NSLocale.preferredLanguages[0]
+        let direction = NSLocale.characterDirection(forLanguage: language)
+        let isRTL =  direction == NSLocale.LanguageDirection.rightToLeft
+        textAlignment = isRTL ? .right : .left
+    }
 }
 
 extension UITextField {

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -123,7 +123,7 @@ open class ALKChatBar: UIView, Localizable {
         view.isUserInteractionEnabled = false
         view.isScrollEnabled = false
         view.scrollsToTop = false
-        view.changeTextDirection()
+        view.changePlaceHolderDirection()
         view.setBackgroundColor(.color(.none))
         return view
     }()
@@ -769,7 +769,7 @@ extension ALKChatBar: UITextViewDelegate {
         action?(.chatBarTextBeginEdit)
         guard textView.text == nil || textView.text.isEmpty else { return }
         textView.changeTextDirection()
-        placeHolder.changeTextDirection()
+        placeHolder.changePlaceHolderDirection()
     }
 
     public func textViewDidEndEditing(_ textView: UITextView) {
@@ -795,7 +795,7 @@ extension ALKChatBar: UITextViewDelegate {
         textView.reloadInputViews()
         guard textView.text == nil || textView.text.isEmpty else { return }
         textView.changeTextDirection()
-        placeHolder.changeTextDirection()
+        placeHolder.changePlaceHolderDirection()
     }
 
     func resetToDefaultPlaceholderText() {


### PR DESCRIPTION
## Summary
ALK Chat Bar Place Holder was not changing the direction for RTL Languages. When we set the RTL as device language & open the app, the place holder direction has not changed.

## Testing
Tested Locally for both LTR & RTL languages, its changing the direction.