### PR TITLE
[CM-842] Add support for s3 service for attachment & make it as default | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 ## Unreleased
+- [CM-842] Added Support for s3 service for upload & download
 - [CM-825] Fixed SPM integration issue
 ## [0.1.2] 2022-01-20
 - Fixed the Stroyboard linking issue

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -5,6 +5,7 @@ use_frameworks!
 
 target 'KommunicateChatUI-iOS-SDK-Demo' do
     pod 'KommunicateChatUI-iOS-SDK', :path => '../KommunicateChatUI-iOS-SDK.podspec'
+ pod 'KommunicateCore-iOS-SDK', :git => 'https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git', :branch => 'dev'
     pod 'SwiftLint'
 end
 

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -5,6 +5,7 @@ use_frameworks!
 
 target 'KommunicateChatUI-iOS-SDK-Demo' do
     pod 'KommunicateChatUI-iOS-SDK', :path => '../KommunicateChatUI-iOS-SDK.podspec'
+    pod 'KommunicateCore-iOS-SDK', :git => 'https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git', :branch => 'google_image_support'
     pod 'SwiftLint'
 end
 

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -5,7 +5,6 @@ use_frameworks!
 
 target 'KommunicateChatUI-iOS-SDK-Demo' do
     pod 'KommunicateChatUI-iOS-SDK', :path => '../KommunicateChatUI-iOS-SDK.podspec'
-    pod 'KommunicateCore-iOS-SDK', :git => 'https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git', :branch => 'google_image_support'
     pod 'SwiftLint'
 end
 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -14,7 +14,6 @@ PODS:
     - SwipeCellKit (~> 2.7.1)
   - KommunicateChatUI-iOS-SDK/RichMessageKit (0.2.0)
   - KommunicateCore-iOS-SDK (1.0.0)
-
   - Nimble (9.2.1)
   - Nimble-Snapshots (9.3.0):
     - Nimble-Snapshots/Core (= 9.3.0)
@@ -28,7 +27,6 @@ PODS:
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
-  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `user_online_away_listener`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -39,6 +37,7 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
+    - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
     - Quick
@@ -49,14 +48,6 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
     :path: "../KommunicateChatUI-iOS-SDK.podspec"
-  KommunicateCore-iOS-SDK:
-    :branch: user_online_away_listener
-    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
-
-CHECKOUT OPTIONS:
-  KommunicateCore-iOS-SDK:
-    :commit: 4946e37d0858cbc9eaa3bc4f298267198ae3c1a1
-    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -70,7 +61,6 @@ SPEC CHECKSUMS:
   SwiftLint: 2c16e8fa99dac2e440dc0c70ea74d2532048f6cf
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: b8dcd9b0779a3894d3dbc63f2d0581b32734fd45
-
+PODFILE CHECKSUM: ceb862bddf2e495511834b44350239c68ccce94f
 
 COCOAPODS: 1.11.2

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -27,6 +27,7 @@ PODS:
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
+  - KommunicateCore-iOS-SDK (from `https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git`, branch `dev`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -37,7 +38,6 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
     - Quick
@@ -48,6 +48,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
     :path: "../KommunicateChatUI-iOS-SDK.podspec"
+  KommunicateCore-iOS-SDK:
+    :branch: dev
+    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
+
+CHECKOUT OPTIONS:
+  KommunicateCore-iOS-SDK:
+    :commit: 12e4f74f8e8d5fa62fc75371f65c6ec52e5e904b
+    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -61,6 +69,6 @@ SPEC CHECKSUMS:
   SwiftLint: 2c16e8fa99dac2e440dc0c70ea74d2532048f6cf
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: ceb862bddf2e495511834b44350239c68ccce94f
+PODFILE CHECKSUM: a54fb83595b8b73b9b0d1aa69f985d15ff306b5f
 
 COCOAPODS: 1.11.2

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -27,6 +27,7 @@ PODS:
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
+  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `google_image_support`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -37,7 +38,6 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
-    - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
     - Quick
@@ -48,6 +48,14 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
     :path: "../KommunicateChatUI-iOS-SDK.podspec"
+  KommunicateCore-iOS-SDK:
+    :branch: google_image_support
+    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
+
+CHECKOUT OPTIONS:
+  KommunicateCore-iOS-SDK:
+    :commit: b8a17e3802f898e072b03c74a237008f0573de4b
+    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -61,6 +69,6 @@ SPEC CHECKSUMS:
   SwiftLint: 2c16e8fa99dac2e440dc0c70ea74d2532048f6cf
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: ceb862bddf2e495511834b44350239c68ccce94f
+PODFILE CHECKSUM: c052c4d5b08db4c2e25069cace704ae8010cc4bf
 
 COCOAPODS: 1.11.2

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -27,7 +27,6 @@ PODS:
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
-  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `google_image_support`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -38,6 +37,7 @@ SPEC REPOS:
   trunk:
     - iOSSnapshotTestCase
     - Kingfisher
+    - KommunicateCore-iOS-SDK
     - Nimble
     - Nimble-Snapshots
     - Quick
@@ -48,14 +48,6 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
     :path: "../KommunicateChatUI-iOS-SDK.podspec"
-  KommunicateCore-iOS-SDK:
-    :branch: google_image_support
-    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
-
-CHECKOUT OPTIONS:
-  KommunicateCore-iOS-SDK:
-    :commit: b8a17e3802f898e072b03c74a237008f0573de4b
-    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -69,6 +61,6 @@ SPEC CHECKSUMS:
   SwiftLint: 2c16e8fa99dac2e440dc0c70ea74d2532048f6cf
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
-PODFILE CHECKSUM: c052c4d5b08db4c2e25069cace704ae8010cc4bf
+PODFILE CHECKSUM: ceb862bddf2e495511834b44350239c68ccce94f
 
 COCOAPODS: 1.11.2

--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -157,8 +157,9 @@ class ALKHTTPManager: NSObject {
         let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let imageFilePath = task.filePath
         let filePath = docDirPath.appendingPathComponent(imageFilePath ?? "")
-        task.fileName = Constants.AWSEncryptedPrefix + task.fileName!
-        
+        if ALApplozicSettings.isS3StorageServiceEnabled() {
+            task.fileName = Constants.AWSEncryptedPrefix + task.fileName!
+        }
         guard let postURLRequest = ALRequestHandler.createPOSTRequest(withUrlString: task.url?.description, paramString: nil) as NSMutableURLRequest? else { return }
         let responseHandler = ALResponseHandler()
         responseHandler.authenticateRequest(postURLRequest) { [weak self] urlRequest, error in

--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -54,6 +54,7 @@ class ALKHTTPManager: NSObject {
         static let attachmentSuffix = "local"
         static let paramForS3Storage = "file"
         static let paramForDefaultStorage = "files[]"
+        static let AWSEncryptedPrefix = "AWS-ENCRYPTED-"
     }
 
     func upload(image: UIImage, uploadURL: URL, completion: @escaping (_ imageLink: Data?) -> Void) {
@@ -156,7 +157,8 @@ class ALKHTTPManager: NSObject {
         let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let imageFilePath = task.filePath
         let filePath = docDirPath.appendingPathComponent(imageFilePath ?? "")
-
+        task.fileName = Constants.AWSEncryptedPrefix + task.fileName!
+        
         guard let postURLRequest = ALRequestHandler.createPOSTRequest(withUrlString: task.url?.description, paramString: nil) as NSMutableURLRequest? else { return }
         let responseHandler = ALResponseHandler()
         responseHandler.authenticateRequest(postURLRequest) { [weak self] urlRequest, error in

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -521,7 +521,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         let serviceEnabled = ALApplozicSettings.isS3StorageServiceEnabled() || ALApplozicSettings.isGoogleCloudServiceEnabled()
 
         if message.fileMetaInfo!.name.hasPrefix(awsEncryptionPrefix) {
-          ALMessageClientService().downloadImageUrl(message.fileMetaInfo?.blobKey) { fileUrl, error in
+          ALMessageClientService().downloadImageUrlV2(message.fileMetaInfo?.blobKey,isS3URL: true) { fileUrl, error in
                guard error == nil, let fileUrl = fileUrl else {
                    print("Error downloading attachment :: \(String(describing: error))")
                    return
@@ -565,7 +565,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
             }
             return
         }
-        ALMessageClientService().downloadImageUrl(message.fileMetaInfo?.blobKey) { fileUrl, error in
+        
+        ALMessageClientService().downloadImageUrlV2(message.fileMetaInfo?.blobKey, isS3URL: message.fileMetaInfo?.url != nil ) { fileUrl, error in
             guard error == nil, let fileUrl = fileUrl else {
                 print("Error downloading attachment :: \(String(describing: error))")
                 return

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -122,7 +122,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
     private var typingTimerTask = Timer()
     private var groupMembers: Set<ALContact>?
-
+    private var awsEncryptionPrefix = "AWS-ENCRYPTED"
+    
     // MARK: - Initializer
 
     public required init(
@@ -519,6 +520,31 @@ open class ALKConversationViewModel: NSObject, Localizable {
         // if ALApplozicSettings.isS3StorageServiceEnabled or ALApplozicSettings.isGoogleCloudServiceEnabled is true its private url we wont be able to download it directly.
         let serviceEnabled = ALApplozicSettings.isS3StorageServiceEnabled() || ALApplozicSettings.isGoogleCloudServiceEnabled()
 
+        if message.fileMetaInfo!.name.hasPrefix(awsEncryptionPrefix) {
+          ALMessageClientService().downloadImageUrl(message.fileMetaInfo?.blobKey) { fileUrl, error in
+               guard error == nil, let fileUrl = fileUrl else {
+                   print("Error downloading attachment :: \(String(describing: error))")
+                   return
+               }
+               let httpManager = ALKHTTPManager()
+               httpManager.downloadDelegate = view as? ALKHTTPManagerDownloadDelegate
+               let task = ALKDownloadTask(downloadUrl: fileUrl, fileName: message.fileMetaInfo?.name)
+               task.identifier = message.identifier
+               task.totalBytesExpectedToDownload = message.size
+               httpManager.downloadCompleted = { [weak self] task in
+                   guard let weakSelf = self, let identifier = task.identifier else { return }
+                   var msg = weakSelf.messageForRow(identifier: identifier)
+                   if ThumbnailIdentifier.hasPrefix(in: identifier) {
+                       msg?.fileMetaInfo?.thumbnailFilePath = task.filePath
+                   } else {
+                       msg?.filePath = task.filePath
+                   }
+               }
+               httpManager.downloadAttachment(task: task)
+           }
+           return
+       }
+        
         if let url = message.fileMetaInfo?.url,
            !serviceEnabled
         {

--- a/Sources/Views/ALKAttatchmentView.swift
+++ b/Sources/Views/ALKAttatchmentView.swift
@@ -80,7 +80,7 @@ class ALKAttatchmentView: UIView {
         }
         // if ALApplozicSettings.isS3StorageServiceEnabled or ALApplozicSettings.isGoogleCloudServiceEnabled is true its private url we wont be able to download it directly.
         let serviceEnabled = ALApplozicSettings.isS3StorageServiceEnabled() || ALApplozicSettings.isGoogleCloudServiceEnabled()
-
+        
         if let url = messageObject.fileMetaInfo?.url,
            !serviceEnabled
         {
@@ -92,7 +92,8 @@ class ALKAttatchmentView: UIView {
             httpManager.downloadImage(task: task)
             return
         }
-        ALMessageClientService().downloadImageUrl(messageObject.fileMetaInfo?.blobKey) { fileUrl, error in
+        
+        ALMessageClientService().downloadImageUrlV2(messageObject.fileMetaInfo?.blobKey, isS3URL: messageObject.fileMetaInfo?.url != nil) { fileUrl, error in
             guard error == nil, let fileUrl = fileUrl else {
                 print("Error downloading attachment :: \(String(describing: error))")
                 return


### PR DESCRIPTION
## Summary
- Added s3 support for upload & download attachments

## Testing
Locally tested by uploading images & checking the URLs.