### PR TITLE
[CM-773] Fix for thumbnail blobkey(empty, spaces) issue

### DIFF
--- a/Sources/Views/ALKVideoCell.swift
+++ b/Sources/Views/ALKVideoCell.swift
@@ -304,22 +304,30 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
         guard let message = viewModel, let metadata = message.fileMetaInfo else {
             return
         }
+        let placeHolderImage = UIImage(named: "VIDEO", in: Bundle.applozic, compatibleWith: nil)
         guard ALApplozicSettings.isS3StorageServiceEnabled() || ALApplozicSettings.isGoogleCloudServiceEnabled() else {
-            let placeHolder = UIImage(named: "VIDEO", in: Bundle.applozic, compatibleWith: nil)
-            photoView.kf.setImage(with: message.thumbnailURL, placeholder: placeHolder)
+            photoView.kf.setImage(with: message.thumbnailURL, placeholder: placeHolderImage)
             return
         }
-        
         /*
             if URL is exist on metadata, then it was upload by S3 Service. if not it was uploaded by Google
-         */        if metadata.url == nil {
-            let placeHolder = UIImage(named: "VIDEO", in: Bundle.applozic, compatibleWith: nil)
-            photoView.kf.setImage(with: message.thumbnailURL, placeholder: placeHolder)
+         */
+        if metadata.url == nil {
+            photoView.kf.setImage(with: message.thumbnailURL, placeholder: placeHolderImage)
             return
         }
-        
+        // If thumbnailblobkey is nil,set thumbnail with placeholder
+        guard let thumbnailBlobKey = metadata.thumbnailBlobKey else {
+            photoView.image = placeHolderImage
+            return
+        }
+        // If thumbanailBlobkey has spaces, remove it before creating the URL.
+        var updatedBlobKey = thumbnailBlobKey
+        if thumbnailBlobKey.contains(" ") {
+            updatedBlobKey = thumbnailBlobKey.replacingOccurrences(of: " ", with: "%20")
+        }
         guard let thumbnailPath = metadata.thumbnailFilePath else {
-            ALMessageClientService().downloadImageThumbnailUrlV2(metadata.thumbnailUrl,isS3URL: metadata.url != nil ,blobKey: metadata.thumbnailBlobKey) { url, error in
+            ALMessageClientService().downloadImageThumbnailUrlV2(metadata.thumbnailUrl,isS3URL: metadata.url != nil ,blobKey: updatedBlobKey) { url, error in
                 guard error == nil,
                       let url = url
                 else {


### PR DESCRIPTION
## Summary
- When image sent from web chat widget,, it has some spaces.due to this, thumbnail was not showing.
- When video sent form web chat widget, thumbnailBlobKey coming as nil.

Fixed above issues by checking for nil & removing the space before creating downloadURL. 
