### PR TITLE
[CM-848] Added localisation support for last message(shown on conversation list screen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
+
+## [Unreleased]
+- [CM-848] Added localisation support for last message of the conversation in Conversationlist screen.
 ## [0.2.0] - 2022-03-22
 - [CM-842] Added Support for s3 service for upload & download
 - [CM-825] Fixed SPM integration issue

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
     - Nimble
   - Quick (4.0.0)
   - SwiftFormat/CLI (0.48.18)
-  - SwiftLint (0.46.5)
+  - SwiftLint (0.47.0)
   - SwipeCellKit (2.7.1)
 
 DEPENDENCIES:
@@ -58,7 +58,7 @@ SPEC CHECKSUMS:
   Nimble-Snapshots: 97270cd48f0e6eebd6c80ccf7dd35d4e57fb9997
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   SwiftFormat: 7dd2b33a0a3d61095b61c911b6d89ff962ae695c
-  SwiftLint: 2c16e8fa99dac2e440dc0c70ea74d2532048f6cf
+  SwiftLint: d41cc46a2ae58ac6d9f26954bc89f1d72e71fdef
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
 
 PODFILE CHECKSUM: ceb862bddf2e495511834b44350239c68ccce94f

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -644,12 +644,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         dateView.setupDate(withDateFormat: date.stringCompareCurrentDate())
         return dateView
     }
-    
-    
-    func getLocalizedStringForDate(_ dateString: String) -> String {
-        return localizedString(forKey: dateString, withDefaultValue: dateString, fileName: configuration.localizedStringFileName)
-    }
-
 
     public func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         guard let message = viewModel.messageForRow(indexPath: indexPath) else {

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -640,10 +640,8 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
 
         // Set view style
         dateView.setupViewStyle()
-        //get the localized string for day
-        let day = getLocalizedStringForDate(date.stringCompareCurrentDate())
         // Set date text
-        dateView.setupDate(withDateFormat: day)
+        dateView.setupDate(withDateFormat: date.stringCompareCurrentDate())
         return dateView
     }
     

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -640,10 +640,18 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
 
         // Set view style
         dateView.setupViewStyle()
+        //get the localized string for day
+        let day = getLocalizedStringForDate(date.stringCompareCurrentDate())
         // Set date text
-        dateView.setupDate(withDateFormat: date.stringCompareCurrentDate())
+        dateView.setupDate(withDateFormat: day)
         return dateView
     }
+    
+    
+    func getLocalizedStringForDate(_ dateString: String) -> String {
+        return localizedString(forKey: dateString, withDefaultValue: dateString, fileName: configuration.localizedStringFileName)
+    }
+
 
     public func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         guard let message = viewModel.messageForRow(indexPath: indexPath) else {

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -296,14 +296,11 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
                 mentionAttributes: attrs as [NSAttributedString.Key: Any],
                 displayNames: displayNames
             )
-        {
+         {
             messageLabel.attributedText = attributedText
         } else {
-            guard  let lastMessage = viewModel.theLastMessage else{
-                messageLabel.text = ""
-                return
-            }
-            messageLabel.text =  localizedString(forKey: lastMessage, withDefaultValue: lastMessage, fileName:localizationFileName)
+            let lastMessage = viewModel.theLastMessage != nil ? localizedString(forKey: viewModel.theLastMessage!, withDefaultValue: viewModel.theLastMessage!, fileName:localizationFileName) :  ""
+            messageLabel.text = lastMessage
         }
 
         muteIcon.isHidden = !isConversationMuted(viewModel: viewModel)

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -299,7 +299,11 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
         {
             messageLabel.attributedText = attributedText
         } else {
-            messageLabel.text = viewModel.theLastMessage
+            guard  let lastMessage = viewModel.theLastMessage else{
+                messageLabel.text = ""
+                return
+            }
+            messageLabel.text =  localizedString(forKey: lastMessage, withDefaultValue: lastMessage, fileName:localizationFileName)
         }
 
         muteIcon.isHidden = !isConversationMuted(viewModel: viewModel)


### PR DESCRIPTION
## Summary
- Added localisation support for label which will be shown on conversation list screen.(the value will be based on the last message of conversation


<img src="https://user-images.githubusercontent.com/61688116/160326049-480bc2f2-fe9c-44af-8b77-f870ec941cd2.png" width="200" height="400">
