### PR TITLE
Fixed lib lint KMCellConfiguration scope issue

### DIFF
--- a/RichMessageKit/Utilities/RMCellConfiguration.swift
+++ b/RichMessageKit/Utilities/RMCellConfiguration.swift
@@ -1,0 +1,15 @@
+//
+//  RMCellConfiguration.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by sathyan elangovan on 22/06/22.
+//
+
+import Foundation
+
+/// - NOTE: Customization for Rich Message  cells
+public enum RMCellConfiguration {
+    
+    /// if true then incoming messsage's sender name will be hidden on conversation
+    public static var hideSenderName = false
+}

--- a/RichMessageKit/Views/ReceivedButtonsCell.swift
+++ b/RichMessageKit/Views/ReceivedButtonsCell.swift
@@ -212,7 +212,7 @@ public class ReceivedButtonsCell: UITableViewCell {
             timeLabelHeight,
             timeLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
         ])
-        nameLabel.isHidden = KMCellConfiguration.hideSenderName
+        nameLabel.isHidden = RMCellConfiguration.hideSenderName
     }
 }
 

--- a/RichMessageKit/Views/ReceivedFAQMessageCell.swift
+++ b/RichMessageKit/Views/ReceivedFAQMessageCell.swift
@@ -180,7 +180,7 @@ public class ReceivedFAQMessageCell: UITableViewCell {
 
         // Set name
         nameLabel.text = model.message.displayName
-        nameLabel.isHidden = KMCellConfiguration.hideSenderName
+        nameLabel.isHidden = RMCellConfiguration.hideSenderName
 
         guard let url = model.message.imageURL else { return }
         ImageCache.downloadImage(url: url) { [weak self] image in

--- a/RichMessageKit/Views/ReceivedImageMessageCell.swift
+++ b/RichMessageKit/Views/ReceivedImageMessageCell.swift
@@ -212,7 +212,7 @@ public class ReceivedImageMessageCell: UITableViewCell {
             timeLabelHeight,
             timeLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -1 * Config.TimeLabel.rightPadding),
         ])
-        nameLabel.isHidden = KMCellConfiguration.hideSenderName
+        nameLabel.isHidden = RMCellConfiguration.hideSenderName
     }
 
     @objc private func imageTapAction() {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1891,6 +1891,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
         /// Rich Message button primary color
         ALKRichMessageStyle.primaryColor = appSettingsUserDefaults.getButtonPrimaryColor()
+        
+        RMCellConfiguration.hideSenderName = KMCellConfiguration.hideSenderName
     }
 
     func setSentMessageStatus() {


### PR DESCRIPTION
## Summary
- KMCellConfiguration file is throwing error when it gets called from `Richmessagekit` module files in lib lint
- When I observed codes we are maintaining separate set of files for `Richmessagekit` configuration for themes, font etc
- Followed the same way created a new class called `RMCellConfiguration` to maintain the configuration for `Richmessage` cells
