### PR TITLE
[CM-945] Gif not playing in conversations when opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
 ## [Unreleased]
-- [CM-935] Added GIF support for Received messages in conversation
+- [CM-935] Added GIF support for Received messages when it expanded to fullscreen mode in conversation
 - [CM-1015] Added Text To Speech feature
 ## [0.2.4] - 2022-06-30
 - [CM-977] Fixed Typing Indicator being shown when user opens the older conversation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
-
+## [Unreleased]
+- Fixed Gif not playing in conversations when opened | iOS
 ## [0.2.2] - 2022-06-23
 - Upgraded KM Core SDK to 1.0.4
 - [Cm-829] Added Typing Indicator Support for Welcome Message

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'KommunicateChatUI-iOS-SDK'
-  s.version = '0.2.2'
+  s.version = '0.2.3'
   s.license = { :type => "BSD 3-Clause", :file => "LICENSE" }
   s.summary = 'KommunicateChatUI-iOS-SDK Kit'
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'

--- a/Sources/Controllers/ALKMediaViewerViewController.swift
+++ b/Sources/Controllers/ALKMediaViewerViewController.swift
@@ -163,7 +163,12 @@ final class ALKMediaViewerViewController: UIViewController {
         else {
             return
         }
-        imageView.image = image
+        // Check for GIF file extension, if its a gif, then set the url using KF.
+        if filePath.hasSuffix(".gif") {
+            imageView.kf.setImage(with: url)
+        } else {
+            imageView.image = image
+        }
         imageView.sizeToFit()
         playButton.isHidden = true
         audioPlayButton.isHidden = true


### PR DESCRIPTION
## Summary
- GIF images are not playing when it expanded to full screen mode in the conversation

Bug:

https://user-images.githubusercontent.com/61688116/182768833-020fecec-b9c4-412e-ad0f-cc48a4746706.mov

After Fix: 

https://user-images.githubusercontent.com/61688116/182768820-0a0689ba-b4f3-42a8-b3a1-3aea2ba2cb27.mov


