### PR TITLE
[CM-977] Fix for typing indicator shown for older conversation when it fetched through api call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
+## [Unreleased]
+- [CM-977] Fixed Typing Indicator being shown when user opens the older conversation
 
 ## [0.2.2] - 2022-06-23
 - Upgraded KM Core SDK to 1.0.4

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -5,14 +5,14 @@ PODS:
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
   - Kingfisher (7.0.0)
-  - KommunicateChatUI-iOS-SDK (0.2.2):
-    - KommunicateChatUI-iOS-SDK/Complete (= 0.2.2)
-  - KommunicateChatUI-iOS-SDK/Complete (0.2.2):
+  - KommunicateChatUI-iOS-SDK (0.2.3):
+    - KommunicateChatUI-iOS-SDK/Complete (= 0.2.3)
+  - KommunicateChatUI-iOS-SDK/Complete (0.2.3):
     - Kingfisher (~> 7.0.0)
     - KommunicateChatUI-iOS-SDK/RichMessageKit
     - KommunicateCore-iOS-SDK (~> 1.0.4)
     - SwipeCellKit (~> 2.7.1)
-  - KommunicateChatUI-iOS-SDK/RichMessageKit (0.2.2)
+  - KommunicateChatUI-iOS-SDK/RichMessageKit (0.2.3)
   - KommunicateCore-iOS-SDK (1.0.4)
   - Nimble (10.0.0)
   - Nimble-Snapshots (9.4.0):
@@ -52,7 +52,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kingfisher: 5efc54fec3980f92354898532e562cc17f31efb4
-  KommunicateChatUI-iOS-SDK: dacdb6d10d022d70d6dbfb241ed92243280e0dab
+  KommunicateChatUI-iOS-SDK: 2403f3402dc9e60d714e756771bdbc7c08ba89cb
   KommunicateCore-iOS-SDK: f4cbf5ee3a11f869d7effaff4270823bb1336991
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Nimble-Snapshots: ef281b908c604f78c8313587e25ea92c8ab513d7

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'KommunicateChatUI-iOS-SDK'
-  s.version = '0.2.2'
+  s.version = '0.2.3'
   s.license = { :type => "BSD 3-Clause", :file => "LICENSE" }
   s.summary = 'KommunicateChatUI-iOS-SDK Kit'
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1027,10 +1027,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                        Timer.scheduledTimer(timeInterval: (timeInterval + 1), target: self, selector: #selector(delayedSecondTimer(timer:)), userInfo: nil, repeats: true)
                    } else {
                        // to give some time gap between previous to next
-                       self.timerTask = Timer.scheduledTimer(timeInterval: timeInterval - 0.3, target: self, selector: #selector(self.invalidateTimerAndUpdateHeightConstraint(_:)), userInfo: nil, repeats: false)
+                       self.timerTask = Timer.scheduledTimer(timeInterval: timeInterval - 0.3, target: self, selector: #selector(self.invalidateTimerAndUpdateHeightConstraint), userInfo: nil, repeats: false)
                    }
                } else {
-                   timerTask = Timer.scheduledTimer(timeInterval: 30.0, target: self, selector: #selector(invalidateTimerAndUpdateHeightConstraint(_:)), userInfo: nil, repeats: false)
+                   timerTask = Timer.scheduledTimer(timeInterval: 30.0, target: self, selector: #selector(invalidateTimerAndUpdateHeightConstraint), userInfo: nil, repeats: false)
                }
            } else {
                timerTask.invalidate()
@@ -1054,16 +1054,16 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
     }
 
-    @objc public func invalidateTimerAndUpdateHeightConstraint(_: Timer?) {
+    @objc public func invalidateTimerAndUpdateHeightConstraint() {
         timerTask.invalidate()
         typingNoticeViewHeighConstaint?.constant = 0
     }
     
     @objc func delayedSecondTimer (timer: Timer) {
-            let timeInterval = TimeInterval(UserDefaults.standard.integer(forKey: "botDelayInterval"))
-            timer.invalidate()
-            self.typingNoticeViewHeighConstaint?.constant = 0
-            Timer.scheduledTimer(timeInterval: timeInterval, target: self, selector: #selector(invalidateTimerAndUpdateHeightConstraint(_:)), userInfo: nil, repeats: false)
+        let timeInterval = TimeInterval(UserDefaults.standard.integer(forKey: "botDelayInterval"))
+        timer.invalidate()
+        self.typingNoticeViewHeighConstaint?.constant = 0
+        Timer.scheduledTimer(timeInterval: timeInterval, target: self, selector: #selector(invalidateTimerAndUpdateHeightConstraint), userInfo: nil, repeats: false)
     }
     
     public func sync(message: ALMessage) {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -453,6 +453,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             }
         }
         unsubscribingChannel()
+        self.invalidateTimerAndUpdateHeightConstraint()
+        self.viewModel.timer.invalidate()
     }
 
     override func backTapped() {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -71,6 +71,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     /// See configuration.
     private var isProfileTapActionEnabled = true
+    
+    private var botDelayTime = 0
+
 
     private var isFirstTime = true
     private var bottomConstraint: NSLayoutConstraint?
@@ -960,6 +963,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         checkUserBlock()
         subscribeChannelToMqtt()
         viewModel.prepareController()
+        let userDefaults = UserDefaults(suiteName: "group.kommunicate.sdk") ?? .standard
+        botDelayTime = userDefaults.integer(forKey: "BOT_MESSAGE_DELAY_INTERVAL") / 1000
     }
 
     @objc open func pushNotification(notification: NSNotification) {
@@ -1021,8 +1026,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         guard typingNoticeViewHeighConstaint?.constant == 0 else { return }
         
         if status {
-               if (UserDefaults.standard.integer(forKey: "botDelayInterval")) > 0 {
-                   let timeInterval = TimeInterval(UserDefaults.standard.integer(forKey: "botDelayInterval"))
+               if botDelayTime > 0 {
+                   let timeInterval = TimeInterval(botDelayTime)
                    if timerTask.isValid {
                        Timer.scheduledTimer(timeInterval: (timeInterval + 1), target: self, selector: #selector(delayedSecondTimer(timer:)), userInfo: nil, repeats: true)
                    } else {
@@ -1060,7 +1065,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
     
     @objc func delayedSecondTimer (timer: Timer) {
-        let timeInterval = TimeInterval(UserDefaults.standard.integer(forKey: "botDelayInterval"))
+        let timeInterval = TimeInterval(botDelayTime)
         timer.invalidate()
         self.typingNoticeViewHeighConstaint?.constant = 0
         Timer.scheduledTimer(timeInterval: timeInterval, target: self, selector: #selector(invalidateTimerAndUpdateHeightConstraint), userInfo: nil, repeats: false)

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1261,12 +1261,12 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
     }
     
+    // Check for Old Conversation based on created time
     func isOldConversation() -> Bool {
         let createdTimeInMilliSec = self.alMessages[0].createdAtTime as? Double ?? 0.0
         let date = NSDate() 
         let currentTimeInMilliSec = date.timeIntervalSince1970 * 1000
         let diff = currentTimeInMilliSec - createdTimeInMilliSec
-        print("pakka10 time diff \(diff)")
         // Checking time difference of 10 seconds.
         if currentTimeInMilliSec - createdTimeInMilliSec < 10000 {
             return false

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1220,10 +1220,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
             self.alMessages = messages.reversed() as! [ALMessage]
             self.alMessageWrapper.addObject(toMessageArray: messages)
             self.modelsToBeAddedAfterDelay = self.alMessages.map { $0.messageModel }
-            //Check for Conversation Assignee to show Typing Indicator
-            if !self.isConversationAssignedToBot() {
-                self.messageModels = self.modelsToBeAddedAfterDelay
-            } else if (UserDefaults.standard.integer(forKey: "botDelayInterval")) > 0 {
+            // Check for Conversation Assignee and conversation first message created time to show Typing Indicator.
+            if self.isConversationAssignedToBot() && (UserDefaults.standard.integer(forKey: "botDelayInterval") > 0) && !self.isOldConversation() {
                 self.showTypingIndicatorForWelcomeMessage()
             } else {
                 self.messageModels = self.modelsToBeAddedAfterDelay
@@ -1261,6 +1259,19 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 showTypingIndicatorForWelcomeMessage()
             }
         }
+    }
+    
+    func isOldConversation() -> Bool {
+        let createdTimeInMilliSec = self.alMessages[0].createdAtTime as? Double ?? 0.0
+        let date = NSDate() 
+        let currentTimeInMilliSec = date.timeIntervalSince1970 * 1000
+        let diff = currentTimeInMilliSec - createdTimeInMilliSec
+        print("pakka10 time diff \(diff)")
+        // Checking time difference of 10 seconds.
+        if currentTimeInMilliSec - createdTimeInMilliSec < 10000 {
+            return false
+        }
+        return true
     }
     
     func isConversationAssignedToBot() -> Bool {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -126,6 +126,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
     private var typingTimerTask = Timer()
     private var groupMembers: Set<ALContact>?
     private var awsEncryptionPrefix = "AWS-ENCRYPTED"
+    private var botDelayTime = 0
+
     
     // MARK: - Initializer
 
@@ -146,6 +148,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
     // MARK: - Public methods
 
     public func prepareController() {
+        let userDefaults = UserDefaults(suiteName: "group.kommunicate.sdk") ?? .standard
+        botDelayTime = userDefaults.integer(forKey: "BOT_MESSAGE_DELAY_INTERVAL") / 1000
+        
         if isSearch {
             delegate?.loadingStarted()
             loadSearchMessages()
@@ -1221,7 +1226,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             self.alMessageWrapper.addObject(toMessageArray: messages)
             self.modelsToBeAddedAfterDelay = self.alMessages.map { $0.messageModel }
             // Check for Conversation Assignee and conversation first message created time to show Typing Indicator.
-            if self.isConversationAssignedToBot() && (UserDefaults.standard.integer(forKey: "botDelayInterval") > 0) && !self.isOldConversation() {
+            if self.isConversationAssignedToBot() && (self.botDelayTime > 0) && !self.isOldConversation() {
                 self.showTypingIndicatorForWelcomeMessage()
             } else {
                 self.messageModels = self.modelsToBeAddedAfterDelay
@@ -1244,7 +1249,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             return
         }
         self.delegate?.updateTyingStatus(status: true, userId: self.alMessages[0].to)
-        let delay = TimeInterval(UserDefaults.standard.integer(forKey: "botDelayInterval"))
+        let delay = TimeInterval(botDelayTime)
         self.timer = Timer.scheduledTimer(withTimeInterval:delay, repeats: false) {[self] timer in
             guard welcomeMessagePosition < modelsToBeAddedAfterDelay.count else{
                 return


### PR DESCRIPTION
## Summary
- Typing indicator delay is showing for older conversation messages when we fetch through api ..Fixed it by comparing created time with current time.
-  Stopped typing timer while exiting the Conversation Screen.

