### PR TITLE
[CM-979] Suggested Reply/ Curved  Button is not supporting multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
-
-## [0.2.2] - 2022-06-23
+## [Unreleased]
+- [CM-979] Fixed Last button of Curved/Quick Reply Button not supporting multiple lines 
+## [0.2.3] - 2022-06-23
 - Upgraded KM Core SDK to 1.0.4
 - [Cm-829] Added Typing Indicator Support for Welcome Message
 - [CM-870] Added onTimeRating flag on ALKConfiguration

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'KommunicateChatUI-iOS-SDK'
-  s.version = '0.2.2'
+  s.version = '0.2.3'
   s.license = { :type => "BSD 3-Clause", :file => "LICENSE" }
   s.summary = 'KommunicateChatUI-iOS-SDK Kit'
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'

--- a/RichMessageKit/Utilities/SuggestedReplyViewSizeCalculator.swift
+++ b/RichMessageKit/Utilities/SuggestedReplyViewSizeCalculator.swift
@@ -28,14 +28,14 @@ class SuggestedReplyViewSizeCalculator {
                 }
                 let currWidth = size.width + 10 // Button Padding
                 if currWidth >= maxWidth {
-                    totalHeight += size.height + prevHeight + 10 // 10 padding between buttons
+                    totalHeight += size.height + prevHeight + 12 // 12 padding between buttons
                     width = 0
                     prevHeight = 0
                     continue
                 }
 
                 if width + currWidth >= maxWidth {
-                    totalHeight += prevHeight + 10 // 10 padding between buttons
+                    totalHeight += prevHeight + 12 // 12 padding between buttons
                     width = currWidth
                     prevHeight = size.height
                 } else {


### PR DESCRIPTION
## Summary
- Last button in Suggested Reply Buttons list is not supporting multiple lines due lack of height provided for the cell

Issue: 
<img src = "https://user-images.githubusercontent.com/61688116/176437261-b8476349-83a1-428c-bdca-5219df4cc9b2.png" width = 250 height = 400 />

Fix: 
<img src = "https://user-images.githubusercontent.com/61688116/176437480-51a472cc-635a-4d19-bffe-a936b480266d.png" width = 250 height = 400 />


