### PR TITLE
[CM-960] Added LongPress Gesture for LinkMessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
-
+## [Unreleased]
+- [CM-960] Added Long press Gesture for Link Messages
 ## [0.2.2] - 2022-06-14
 - Upgraded KM Core SDK to 1.0.3
 - [Cm-829] Added Typing Indicator Support for Welcome Message

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -51,13 +51,14 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         case .text, .html, .email:
             if !configuration.isLinkPreviewDisabled, message.messageType == .text, ALKLinkPreviewManager.extractURLAndAddInCache(from: message.message, identifier: message.identifier) != nil {
                 var cell = ALKLinkPreviewBaseCell()
-                cell.menuOptionsToShow = configuration.messageMenuOptions
                 if message.isMyMessage {
                     cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as ALKMyLinkPreviewCell
+                    cell.menuOptionsToShow = configuration.messageMenuOptions
                     cell.showReport = false
                     necessarySetupForMessageCell(cell: cell, message: message)
                 } else {
                     cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as ALKFriendLinkPreviewCell
+                    cell.menuOptionsToShow = configuration.messageMenuOptions
                     cell.showReport = true
                     cell.avatarTapped = { [weak self] in
                         guard let currentModel = cell.viewModel else { return }

--- a/Sources/Views/ALKChatBaseCell.swift
+++ b/Sources/Views/ALKChatBaseCell.swift
@@ -92,8 +92,8 @@ open class ALKChatBaseCell<T>: ALKBaseCell<T>, Localizable {
         }
     }
     
-    
-    func showMenuControllerForLink(_ view : UIView) {
+    // To show Menu Controller if user long presses the Link
+    func showMenuControllerForLink(_ gestureView : UIView) {
         NotificationCenter.default.addObserver(self, selector: #selector(menuWillShow(_:)), name: UIMenuController.willShowMenuNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(menuWillHide(_:)), name: UIMenuController.willHideMenuNotification, object: nil)
 
@@ -103,10 +103,8 @@ open class ALKChatBaseCell<T>: ALKBaseCell<T>, Localizable {
             _ = canBecomeFirstResponder
         }
 
-        let gestureView = view
-        guard let superView = view.superview else {return}
+        guard let superView = gestureView.superview else {return}
         
-
         let menuController = UIMenuController.shared
 
         guard !menuController.isMenuVisible, gestureView.canBecomeFirstResponder else {
@@ -133,7 +131,7 @@ open class ALKChatBaseCell<T>: ALKBaseCell<T>, Localizable {
         menuController.setTargetRect(gestureView.frame, in: superView)
         menuController.setMenuVisible(true, animated: true)
     }
-
+    
     override open var canBecomeFirstResponder: Bool {
         return true
     }

--- a/Sources/Views/ALKChatBaseCell.swift
+++ b/Sources/Views/ALKChatBaseCell.swift
@@ -91,6 +91,48 @@ open class ALKChatBaseCell<T>: ALKBaseCell<T>, Localizable {
             menuController.setMenuVisible(true, animated: true)
         }
     }
+    
+    
+    func showMenuControllerForLink(_ view : UIView) {
+        NotificationCenter.default.addObserver(self, selector: #selector(menuWillShow(_:)), name: UIMenuController.willShowMenuNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(menuWillHide(_:)), name: UIMenuController.willHideMenuNotification, object: nil)
+
+        if let chatBar = chatBar, chatBar.textView.isFirstResponder {
+            chatBar.textView.overrideNextResponder = contentView
+        } else {
+            _ = canBecomeFirstResponder
+        }
+
+        let gestureView = view
+        guard let superView = view.superview else {return}
+        
+
+        let menuController = UIMenuController.shared
+
+        guard !menuController.isMenuVisible, gestureView.canBecomeFirstResponder else {
+            return
+        }
+
+        gestureView.becomeFirstResponder()
+
+        var menus: [UIMenuItem] = []
+
+        if let copyMenu = getCopyMenuItem(copyItem: self) {
+            menus.append(copyMenu)
+        }
+
+        if let replyMenu = getReplyMenuItem(replyItem: self) {
+            menus.append(replyMenu)
+        }
+
+        if showReport, let reportMessageMenu = getReportMessageItem(reportMessageItem: self) {
+            menus.append(reportMessageMenu)
+        }
+
+        menuController.menuItems = menus
+        menuController.setTargetRect(gestureView.frame, in: superView)
+        menuController.setMenuVisible(true, animated: true)
+    }
 
     override open var canBecomeFirstResponder: Bool {
         return true

--- a/Sources/Views/ALKChatBaseCell.swift
+++ b/Sources/Views/ALKChatBaseCell.swift
@@ -92,46 +92,6 @@ open class ALKChatBaseCell<T>: ALKBaseCell<T>, Localizable {
         }
     }
     
-    // To show Menu Controller if user long presses the Link
-    func showMenuControllerForLink(_ gestureView : UIView) {
-        NotificationCenter.default.addObserver(self, selector: #selector(menuWillShow(_:)), name: UIMenuController.willShowMenuNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(menuWillHide(_:)), name: UIMenuController.willHideMenuNotification, object: nil)
-
-        if let chatBar = chatBar, chatBar.textView.isFirstResponder {
-            chatBar.textView.overrideNextResponder = contentView
-        } else {
-            _ = canBecomeFirstResponder
-        }
-
-        guard let superView = gestureView.superview else {return}
-        
-        let menuController = UIMenuController.shared
-
-        guard !menuController.isMenuVisible, gestureView.canBecomeFirstResponder else {
-            return
-        }
-
-        gestureView.becomeFirstResponder()
-
-        var menus: [UIMenuItem] = []
-
-        if let copyMenu = getCopyMenuItem(copyItem: self) {
-            menus.append(copyMenu)
-        }
-
-        if let replyMenu = getReplyMenuItem(replyItem: self) {
-            menus.append(replyMenu)
-        }
-
-        if showReport, let reportMessageMenu = getReportMessageItem(reportMessageItem: self) {
-            menus.append(reportMessageMenu)
-        }
-
-        menuController.menuItems = menus
-        menuController.setTargetRect(gestureView.frame, in: superView)
-        menuController.setMenuVisible(true, animated: true)
-    }
-    
     override open var canBecomeFirstResponder: Bool {
         return true
     }

--- a/Sources/Views/ALKLinkPreviewBaseCell.swift
+++ b/Sources/Views/ALKLinkPreviewBaseCell.swift
@@ -25,6 +25,7 @@ class ALKLinkPreviewBaseCell: ALKMessageCell {
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(openUrl))
         linkView.frontView.addGestureRecognizer(tapGesture)
+        messageView.delegate = self
     }
 
     override func setupStyle() {
@@ -45,5 +46,51 @@ class ALKLinkPreviewBaseCell: ALKMessageCell {
 
     func isCellVisible(_ closure: @escaping ((_ identifier: String) -> Bool)) {
         linkView.isViewCellVisible = closure
+    }
+    
+    // To show Menu Controller if user long presses the Link
+    func showMenuControllerForLink(_ gestureView : UIView) {
+        NotificationCenter.default.addObserver(self, selector: #selector(menuWillShow(_:)), name: UIMenuController.willShowMenuNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(menuWillHide(_:)), name: UIMenuController.willHideMenuNotification, object: nil)
+
+        guard let superView = gestureView.superview else {return}
+        
+        let menuController = UIMenuController.shared
+
+        guard !menuController.isMenuVisible, gestureView.canBecomeFirstResponder else {
+            return
+        }
+
+        gestureView.becomeFirstResponder()
+
+        var menus: [UIMenuItem] = []
+
+        if let copyMenu = getCopyMenuItem(copyItem: self) {
+            menus.append(copyMenu)
+        }
+
+        if let replyMenu = getReplyMenuItem(replyItem: self) {
+            menus.append(replyMenu)
+        }
+
+        if showReport, let reportMessageMenu = getReportMessageItem(reportMessageItem: self) {
+            menus.append(reportMessageMenu)
+        }
+
+        menuController.menuItems = menus
+        menuController.setTargetRect(gestureView.frame, in: superView)
+        menuController.setMenuVisible(true, animated: true)
+    }
+}
+extension ALKLinkPreviewBaseCell: UITextViewDelegate {
+    public func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction: UITextItemInteraction) -> Bool {
+        guard let message = viewModel else { return true }
+        // Check for interaction type then proceed. 0 -> Tap , 1 -> Longpress
+        if interaction.rawValue == 0 {
+            delegate?.urlTapped(url: URL, message: message)
+        } else if interaction.rawValue == 1 {
+            showMenuControllerForLink(self)
+        }
+        return false
     }
 }

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -479,11 +479,10 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
 extension ALKMessageCell: UITextViewDelegate {
     public func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction: UITextItemInteraction) -> Bool {
         guard let message = viewModel else { return true }
+        // Check for interaction type then proceed. 0 -> Tap , 1 -> Longpress
         if interaction.rawValue == 0 {
-            print("Deteceted single  tap")
             delegate?.urlTapped(url: URL, message: message)
         } else if interaction.rawValue == 1 {
-            print("Detected long press")
             showMenuControllerForLink(self)
         }
         return false

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -243,7 +243,6 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
         bubbleView.addGestureRecognizer(longPressGesture)
         let replyTapGesture = UITapGestureRecognizer(target: self, action: #selector(replyViewTapped))
         replyView.addGestureRecognizer(replyTapGesture)
-        messageView.delegate = self
     }
 
     override func setupStyle() {
@@ -475,17 +474,3 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
         }
     }
 }
-
-extension ALKMessageCell: UITextViewDelegate {
-    public func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction: UITextItemInteraction) -> Bool {
-        guard let message = viewModel else { return true }
-        // Check for interaction type then proceed. 0 -> Tap , 1 -> Longpress
-        if interaction.rawValue == 0 {
-            delegate?.urlTapped(url: URL, message: message)
-        } else if interaction.rawValue == 1 {
-            showMenuControllerForLink(self)
-        }
-        return false
-    }
-}
-

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -477,9 +477,16 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
 }
 
 extension ALKMessageCell: UITextViewDelegate {
-    public func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction _: UITextItemInteraction) -> Bool {
+    public func textView(_: UITextView, shouldInteractWith URL: URL, in _: NSRange, interaction: UITextItemInteraction) -> Bool {
         guard let message = viewModel else { return true }
-        delegate?.urlTapped(url: URL, message: message)
+        if interaction.rawValue == 0 {
+            print("Deteceted single  tap")
+            delegate?.urlTapped(url: URL, message: message)
+        } else if interaction.rawValue == 1 {
+            print("Detected long press")
+            showMenuControllerForLink(self)
+        }
         return false
     }
 }
+


### PR DESCRIPTION
## Summary
-  Added LongPress Gesture for LinkMessages
- In Existing version if user sends, receives message which contains link, they can't copy that link by longpress it.

Existing:

https://user-images.githubusercontent.com/61688116/183840733-a8f304f7-f685-4c5e-a084-23668f72b812.mov

After this fix:

https://user-images.githubusercontent.com/61688116/183840688-7453fa37-8e11-40b8-8a74-2b07e0ab3c4b.mov

 


