### PR TITLE
[CM-998] - Remove default Reply option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 
 ## [Unreleased]
 - [CM-960] Added Long press Gesture for Link Messages
+- [CM-998] Stop Exposing Reply option in Conversation
 ## [0.2.5] - 2022-08-08
 - Fixed Feedback, Rating Font and color mismatch issue
 - [CM-935] Added GIF support for Received messages when it expanded to fullscreen mode in conversation

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -155,7 +155,7 @@ public struct ALKConfiguration {
     public var isNewSystemPhotosUIEnabled = false
 
     /// Set the message menu options to show on the message long tap.
-    public var messageMenuOptions: [ALKMessageCell.MenuOption] = [.copy, .reply]
+    public var messageMenuOptions: [ALKMessageCell.MenuOption] = [.copy]
     
     // If true then TTS(Text To Speech) is enabled. It is false by default.
     public var enableTextToSpeechInConversation: Bool = false


### PR DESCRIPTION
- Remove default reply option from Message Info menu

![image](https://user-images.githubusercontent.com/22256112/184817661-e3f7c998-7ea8-490a-a173-1e9a4e086348.png)
