### PR TITLE
[CM-888] iOS Firebase crash | ALMessage+Extension.swift line 360 

### DIFF
--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -352,12 +352,12 @@ extension ALMessage {
     }
 
     private func getAttachmentType() -> ALKMessageType? {
-        guard let fileMeta = fileMeta else { return nil }
-        if fileMeta.contentType.hasPrefix("image") {
+        guard let fileMeta = fileMeta, let contentType = fileMeta.contentType else { return nil }
+        if contentType.hasPrefix("image") {
             return .photo
-        } else if fileMeta.contentType.hasPrefix("audio") {
+        } else if contentType.hasPrefix("audio") {
             return .voice
-        } else if fileMeta.contentType.hasPrefix("video") {
+        } else if contentType.hasPrefix("video") {
             return .video
         } else {
             return .document


### PR DESCRIPTION
## Summary
- agent app is crashed when checking the attachment type using the prefix
- Added a nil check for the content type of file meta to fix the crash as couldn't reproduce the issue for all attachment combinations.
