### PR TITLE
SPM Integration Build Issue

### DIFF
--- a/Sources/Utilities/RatingHelper.swift
+++ b/Sources/Utilities/RatingHelper.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import UIKit
+
 class RatingHelper : Localizable {
 
      var configuration = ALKConfiguration()


### PR DESCRIPTION
## Summary
- Without  ` import UIKit` causing Build issue on UIImages on RatingHelper.swift file when integrate through SPM only
- Tested it after this fix by pointing to the commit hash in a Sample SPM App

## Note
- To avoid issues like this in future, adding sample SPM app in bitrise & its build will be verified before every release in iOS SDK.
