### PR TITLE
[CM-1156] Fixed form issue for small  devices

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2066,9 +2066,6 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             moveTableViewToBottom(indexPath: indexPath)
             isViewLoadedFromTappingOnNotification = false
         } else if tableView.isCellVisible(section: lastSectionBeforeUpdate - 1, row: 0) {
-            if let lastMessage = viewModel.messageModels.last {
-                reloadIfFormMessage(message: lastMessage, indexPath: indexPath)
-            }
             moveTableViewToBottom(indexPath: indexPath)
         } else if viewModel.messageModels.count > 1 { // Check if the function is called before message is added. It happens when user is added in the group.
             unreadScrollButton.isHidden = false


### PR DESCRIPTION
## Summary
- Form template messages getting cropped when it is arrived

## route cause
- refreshing the form again for second is cropping the the form. We are refreshing the cell again if its form message, its causing the issue. So removing the refreshing flow

