### PR TITLE
[CM-1217] Zendesk Authentication & Chat Session

### DIFF
--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -6,7 +6,7 @@ use_frameworks!
 target 'KommunicateChatUI-iOS-SDK-Demo' do
     pod 'KommunicateChatUI-iOS-SDK', :path => '../KommunicateChatUI-iOS-SDK.podspec'
     pod 'SwiftLint'
-    pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git', :branch => 'CM-1189'
+    pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git', :branch => 'dev'
 end
 
 target 'KommunicateChatUI-iOS-SDK-DemoTests' do

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
-  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `CM-1189`)
+  - KommunicateCore-iOS-SDK (from `https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git`, branch `dev`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -68,13 +68,13 @@ EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
     :path: "../KommunicateChatUI-iOS-SDK.podspec"
   KommunicateCore-iOS-SDK:
-    :branch: CM-1189
-    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
+    :branch: dev
+    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
 
 CHECKOUT OPTIONS:
   KommunicateCore-iOS-SDK:
-    :commit: e066da47b1cf48839de83e27b9949b873bbff54e
-    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
+    :commit: 85ad537f0c89efc4df31c84e5535dec836ce9498
+    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -94,6 +94,6 @@ SPEC CHECKSUMS:
   ZendeskMessagingSDK: 4f5f3d43766bb3b2ea6411d1331cfe609ff33618
   ZendeskSDKConfigurationsSDK: a5c21010e17b71d02bc2cfe73dcc9da1efa0a7b2
 
-PODFILE CHECKSUM: e1d7de8758864c33f4b63ea768d363056ae46030
+PODFILE CHECKSUM: 71488a83c7d10d1b95777caee09b684fe55dc2f2
 
 COCOAPODS: 1.11.3

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -73,7 +73,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   KommunicateCore-iOS-SDK:
-    :commit: 0b6cc76b82b325e33afabd76b0c89b3f70c5ba61
+    :commit: e066da47b1cf48839de83e27b9949b873bbff54e
     :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1129,7 +1129,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
               let metadata = message.metadata,
               let _ = metadata["KM_ASSIGN_TO"] as? String else { return }
         
-        KMZendeskChatHandler.shared.initiateZendesk(key: zendeskKey, conversationId: groupId.stringValue)
+        KMZendeskChatHandler.shared.handedOffToAgent(groupId: groupId.stringValue)
     }
 
     public func updateDeliveryReport(messageKey: String?, contactId _: String?, status: Int32?) {

--- a/Sources/Utilities/KMZendeskChatHandler.swift
+++ b/Sources/Utilities/KMZendeskChatHandler.swift
@@ -15,59 +15,41 @@ struct KommunicateURL {
     static let dashboardURL = "https://dashboard.kommunicate.io/conversations/"
 }
 
-public class KMZendeskChatHandler {
-
-    public static let shared = KMZendeskChatHandler()
+public class KMZendeskChatHandler : NSObject, JWTAuthenticator {
+  
+    public func getToken(_ completion: @escaping (String?, Error?) -> Void) {
+        completion(jwtToken,nil)
+    }
+    
+   public static let shared = KMZendeskChatHandler()
     var groupId: String = ""
-    var connectionStatus = false
-    var messages:[ALMessage]? = nil
     var zenChatIntialized = false
     var userId = ""
     var isChatTranscriptSent = false
+    var isHandOffHappened = false
+    var lastUserMessageCreatedTime: NSNumber = 0
+    var messageBufffer = [ALMessage]()
+
+    var jwtToken: String = "" {
+            didSet {
+                guard !jwtToken.isEmpty else {
+                    resetIdentity()
+                    return
+                }
+                Chat.instance?.setIdentity(authenticator: self)
+            }
+        }
     
-    public func initiateZendesk(key: String, conversationId: String) {
+    public func initiateZendesk(key: String) {
         Chat.initialize(accountKey: key)
-        groupId = conversationId
         zenChatIntialized = true
         fetchUserId()
         authenticateUser()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            self.sendChatInfo()
-            self.sendChatTranscript()
-            
-            let connectionToken = Chat.connectionProvider?.observeConnectionStatus { [weak self] (connection) in
-                // Handle connection status changes
-                guard let weakSelf = self,
-                      connection.isConnected,
-                      self?.connectionStatus != true else {
-                   self?.connectToZendeskSocket()
-                   return
-                }
-                weakSelf.connectionStatus = true
-                weakSelf.observeChatLogs()
-                if !weakSelf.isChatTranscriptSent {
-                    weakSelf.sendChatTranscript()
-                }
-           }
-       }
     }
     
-    func fetchUserId() {
-        guard let id = ALUserDefaultsHandler.getUserId() else {return}
-        self.userId = id
+    public func updateHandoff(_ value: Bool) {
+        self.isHandOffHappened = value
     }
-    
-    public func getGroupId() -> String {
-        return groupId
-    }
-    func authenticateUser() {
-        let chatAPIConfiguration = ChatAPIConfiguration()
-        chatAPIConfiguration.visitorInfo = VisitorInfo(name: ALUserDefaultsHandler.getDisplayName() ?? "", email: ALUserDefaultsHandler.getEmailId() ?? "", phoneNumber: "")
-        Chat.instance?.configuration = chatAPIConfiguration
-        connectToZendeskSocket()
-    }
-    var chatLogToken : ObservationToken?
     
     func observeChatLogs() {
         guard Chat.connectionProvider?.status == .connected else {
@@ -77,24 +59,108 @@ public class KMZendeskChatHandler {
         
         let stateToken = Chat.chatProvider?.observeChatState { (state) in
             // Handle logs, agent events, queue position changes and other events
+            self.processChatLogs(logs: state.logs)
         }
+        // TODO: Handle Disconnection of all observe token
         chatLogToken = stateToken
+        
+        let connectionToken = Chat.connectionProvider?.observeConnectionStatus { [self] (connection) in
+            // Handle connection status changes
+            guard connection.isConnected else {
+               return
+            }
+       }
     }
     
+    func fetchUserId() {
+        guard let id = ALUserDefaultsHandler.getUserId() else {return}
+        self.userId = id
+    }
+    
+    public func handedOffToAgent(groupId: String) {
+        self.groupId = groupId
+        isHandOffHappened = true
+        sendChatInfo()
+        sendChatTranscript()
+    }
+
+    
+    public func getGroupId() -> String {
+        return groupId
+    }
+    public func updategroupId(_ groupId: String) {
+        self.groupId = groupId
+        self.updateLastMessageCreatedTime()
+    }
+   
+    func authenticateUser() {
+        let userHandler = ALUserDefaultsHandler.self
+        
+        if let externalId = userHandler.getUserId(),!externalId.isEmpty,
+           let name = userHandler.getDisplayName(),!name.isEmpty,
+           let email = userHandler.getEmailId(),!email.isEmpty {
+            authenticateUserWithJWT(name: name, email: email, externalId: externalId)
+        }
+    }
+    
+    
+    
+    func authenticateUserWithJWT(name: String, email: String, externalId: String) {
+        let dictionary = ["name":name, "email": email, "externalId":externalId]
+
+        let postdata: Data? = try? JSONSerialization.data(withJSONObject: dictionary, options: [])
+        var theParamString: String? = nil
+        if let aPostdata = postdata {
+            theParamString = String(data: aPostdata, encoding: .utf8)
+        }
+        
+        guard let postURLRequest = ALRequestHandler.createPOSTRequest(withUrlString: "https://api.kommunicate.io/rest/ws/zendesk/jwt", paramString: theParamString) as NSMutableURLRequest? else { return }
+        let responseHandler = ALResponseHandler()
+        
+        responseHandler.authenticateAndProcessRequest(postURLRequest, andTag: "") {
+            (json, error) in
+            guard error == nil else {
+                return
+            }
+            guard let dict = json as? [String: Any], let data = dict["data"] as? [String: Any], let jwtKey = data["jwt"] as? String else {
+                return
+            }
+            self.jwtToken = jwtKey
+            // Connect to their server after authentication
+            self.connectToZendeskSocket()
+
+        }
+    }
+    
+    var chatLogToken : ObservationToken?
+    
     func connectToZendeskSocket() {
-        Chat.connectionProvider?.connect()
+        guard let connectionProvider = Chat.connectionProvider else {
+            return
+        }
+        connectionProvider.connect()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.observeChatLogs()
+        }
     }
     
     func sendMessage(message: ALMessage) {
-        guard Chat.connectionProvider?.status == .connected else {
+        guard isHandOffHappened else {return}
+        
+        guard let connectionProvider = Chat.connectionProvider, connectionProvider.status == .connected else {
+            addMessageToBuffer(message: message)
             connectToZendeskSocket()
             return
         }
-        
         sendMessageToZendesk(message: message.message) { (result) in
             switch result {
             case .success:
                 print("Message Sent to Zendesk Successfully")
+                self.lastUserMessageCreatedTime = message.createdAtTime
+                if self.messageBufffer.contains(message) {
+                    self.messageBufffer.remove(object: message)
+                }
             case .failure(let error):
                 print("Failed Send the Message to Zendesk \(error)")
             }
@@ -102,27 +168,40 @@ public class KMZendeskChatHandler {
     }
     
     func sendMessageToZendesk(message: String, completionHandler: @escaping (Result<String, ChatProvidersSDK.DeliveryStatusError>) -> Void) {
+        guard let connectionProvider = Chat.connectionProvider, connectionProvider.status == .connected else {
+            connectToZendeskSocket()
+            return
+        }
         Chat.chatProvider?.sendMessage(message) { (result) in
+            print("send message result \(result) for message \(message)")
             completionHandler(result)
         }
     }
     
-    func sendChatTranscript() {
-        let chanelKey = NSNumber(value: Int(groupId) ?? 0)
-        let messageListRequest = MessageListRequest()
-        messageListRequest.channelKey = chanelKey
-        
-        if let channel = ALChannelService().getChannelByKey(chanelKey) {
-            messageListRequest.channelType = channel.type
+    func addMessageToBuffer(message:ALMessage) {
+        guard !messageBufffer.contains(message) else {
+            return
         }
-        
-        ALMessageClientService().getMessageList(forUser: messageListRequest) { messages,error,userArray in
+        messageBufffer.append(message)
+    }
+    
+    func sendChatTranscript() {
+        let channelKey = NSNumber(value: Int(groupId) ?? 0)
+        guard channelKey != 0 else {
+            print("Failed to fetch messages for group Id")
+            return
+        }
+     
+        fetchMessages(channelKey:channelKey){[self] messages,error,userArray in
+            print("FETCHED MESSAGES FOR CHAT TRANSCRIPT")
             guard let messageList = messages,
                   let userDetails = userArray as? [ALUserDetail],
                   !userDetails.isEmpty,
                   let almessages = messageList.reversed() as? [ALMessage] else {
                 return
             }
+            // Set Last user Message created time
+            lastUserMessageCreatedTime = almessages.last?.createdAtTime ?? 0
             var transcriptString = "Transcript:\n"
 
             for currentMessage in almessages {
@@ -132,14 +211,14 @@ public class KMZendeskChatHandler {
                     userName = "User"
                 } else {
                     //get the bot name
-                    userName = self.getBotNameById(botId: currentMessage.to, userdetails: userDetails)
+                    userName = getBotNameById(botId: currentMessage.to, userdetails: userDetails)
                 }
-                let message = self.getMessageForTranscript(message: currentMessage)
+                let message = getMessageForTranscript(message: currentMessage)
                 guard !userName.isEmpty && !message.isEmpty else {continue}
                 transcriptString.append("\(userName): \(message)\n")
             }
-            
-            self.sendMessageToZendesk(message: transcriptString, completionHandler: { (result) in
+
+            sendMessageToZendesk(message: transcriptString, completionHandler: { (result) in
                 switch result {
                 case .success:
                     self.isChatTranscriptSent = true
@@ -154,10 +233,16 @@ public class KMZendeskChatHandler {
     func getBotNameById(botId: String,userdetails:[ALUserDetail]) -> String {
         for userdetail in userdetails {
             if userdetail.userId == botId {
-                return userdetail.displayName
+                return userdetail.displayName ?? ""
             }
         }
         return ""
+    }
+    
+    func processChatLogs(logs: [ChatLog]) {
+        guard lastUserMessageCreatedTime != 0 else { return }
+        let filteredArray = logs.filter{$0.createdTimestamp >= TimeInterval(truncating: lastUserMessageCreatedTime)}
+        processAgentMessage(message: filteredArray)
     }
     
     func getMessageForTranscript(message:ALMessage) -> String {
@@ -173,8 +258,8 @@ public class KMZendeskChatHandler {
     }
     
     func sendChatInfo() {
-        let infoString = "This chat is initiated from Kommunicate widget, look for more here: \(KommunicateURL.dashboardURL)\(groupId)"
-        
+        let infoString = "This chat is initiated from kommunicate widget, look for more here: \(KommunicateURL.dashboardURL)\(groupId)"
+
         sendMessageToZendesk(message: infoString, completionHandler: {(result) in
             switch result {
             case .success(let messageId):
@@ -183,13 +268,12 @@ public class KMZendeskChatHandler {
               print("Failed to send info message due to \(error)")
             }
         })
-
     }
     
     public func disconnectFromZendesk() {
-        Chat.chatProvider?.endChat()
-        chatLogToken?.cancel()
         Chat.connectionProvider?.disconnect()
+        resetLocal()
+        resetIdentity()
     }
     
     func sendAttachment(message:ALMessage){
@@ -198,15 +282,16 @@ public class KMZendeskChatHandler {
                 print("Error Finding attachment URL :: \(String(describing: error))")
                 return
             }
-            
+            print("pakka101 sendding attachment url \(url)")
+
             Chat.chatProvider?.sendFile(url:url , onProgress: { (progress) in
                 print("attachment progress \(progress)")}, completion: { result in
                     switch result {
                         case .success:
-                            print("Attachment sent to zendesk successfully. URL : \(fileUrl)")
+                            print("Attachment sent to zendesk successfully")
                             break
                         case .failure(let error):
-                            print("Failed to send attachment  \(fileUrl) due to \(error)")
+                            print("Failed to send attachment \(error)")
                             break
                     }
                 })
@@ -215,13 +300,14 @@ public class KMZendeskChatHandler {
         
     public func isChatGoingOn(completion: @escaping (Bool) -> Void) {
         // This API proactively connects to web sockets for authenticated users. This connection is kept alive. You should call disconnect() on the ConnectionProvider if you don't need to keep it open.
-        guard let chatProvider = Chat.chatProvider else { return completion(false) }
+        guard let chatProvider = Chat.chatProvider else {
+            return completion(false)
+        }
         chatProvider.getChatInfo { (result) in
             switch result {
             case .success(let chatInfo):
                 completion(chatInfo.isChatting)
             case .failure(let error):
-                print("Failed to get chat info \(error)")
                 completion(false)
             }
         }
@@ -233,5 +319,56 @@ public class KMZendeskChatHandler {
         }
         return true
     }
+    
+    func updateLastMessageCreatedTime() {
+        let channelKey = NSNumber(value: Int(groupId) ?? 0)
+        guard channelKey != 0 else {
+            print("Failed to fetch messages for group Id")
+            return
+        }
+        
+        fetchMessages(channelKey: channelKey){ messages,error,userArray in
+            guard let messageList = messages,
+                  let almessages = messageList.reversed() as? [ALMessage] else {
+                return
+            }
+            self.lastUserMessageCreatedTime = almessages.last?.createdAtTime ?? 0
+        }
+    }
+    
+    func resetLocal() {
+        isHandOffHappened = false
+        zenChatIntialized = false
+    }
+    
+    func processBufferMessages() {
+        for message in messageBufffer {
+            sendMessage(message: message)
+        }
+    }
+    
+    func processAgentMessage(message: [ChatLog]) {
+        // TODO: Send only Agent messsages to Kommunicate Server via api
+        // TODO: Call resolve api when zendesk agent leaves the conversation
+    }
+    
+    func fetchMessages(channelKey: NSNumber,completion: @escaping (_ messages: NSMutableArray?, _ error: Error?, _ userDetails: NSMutableArray?) -> Void) {
+        
+        let messageListRequest = MessageListRequest()
+        messageListRequest.channelKey = channelKey
+        if let channel = ALChannelService().getChannelByKey(channelKey) {
+            messageListRequest.channelType = channel.type
+        }
+        
+        ALMessageClientService().getMessageList(forUser: messageListRequest, withOpenGroup: messageListRequest.channelType == 6) { messages,error,userArray in
+            completion(messages,error,userArray)
+        }
+    }
+    
+    func resetIdentity() {
+        /// Any ongoing chat will be ended, and locally stored information about the visitor will be cleared
+        Chat.instance?.resetIdentity {}
+    }
 }
+
 

--- a/Sources/Utilities/KMZendeskChatHandler.swift
+++ b/Sources/Utilities/KMZendeskChatHandler.swift
@@ -276,6 +276,7 @@ public class KMZendeskChatHandler : NSObject, JWTAuthenticator {
         isHandOffHappened = false
         zenChatIntialized = false
         lastUserMessageCreatedTime = 0
+        messageBufffer.removeAll()
     }
     
     func sendAttachment(message:ALMessage){


### PR DESCRIPTION
## Summary
- Added authentication with jwt for zendesk user
- optimized handoff flow
- updated zendesk intialization flow & connection to zendesk server
- Added message buffer for failed messages incase of zendesk connection lost
- Handled the chat logs for agent messages

New Conversation Flow:
1. Once conversation created, zendesk will be intialized (only for Zendesk users) and users will be authenticated. 
2. when handoff happens , zendeskhandler will start to process user messages to zendesk.

Existing Conversation Flow:
1. While opening the existing conversation, assignee will be checked & handoff flag will be updated accordingly
2. Users will be authenticated & will start observing chat logs(Chat Events). if any new log(message, event) is there , that log will be processed.
