### PR TITLE
[CM-1191] Observe Zendesk Chat Events

### DIFF
--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -6,7 +6,7 @@ use_frameworks!
 target 'KommunicateChatUI-iOS-SDK-Demo' do
     pod 'KommunicateChatUI-iOS-SDK', :path => '../KommunicateChatUI-iOS-SDK.podspec'
     pod 'SwiftLint'
-    pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git', :branch => 'dev'
+    pod 'KommunicateCore-iOS-SDK' , :git => 'https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git', :branch => 'CM-1191'
 end
 
 target 'KommunicateChatUI-iOS-SDK-DemoTests' do

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
-  - KommunicateCore-iOS-SDK (from `https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git`, branch `dev`)
+  - KommunicateCore-iOS-SDK (from `https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git`, branch `CM-1191`)
   - Nimble
   - Nimble-Snapshots
   - Quick
@@ -68,13 +68,13 @@ EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
     :path: "../KommunicateChatUI-iOS-SDK.podspec"
   KommunicateCore-iOS-SDK:
-    :branch: dev
-    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
+    :branch: CM-1191
+    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 CHECKOUT OPTIONS:
   KommunicateCore-iOS-SDK:
-    :commit: 85ad537f0c89efc4df31c84e5535dec836ce9498
-    :git: https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git
+    :commit: bb02f7c179a0152c21c0a5eb8acb13e18509d0ac
+    :git: https://github.com/Sathyan-Elangovan/KommunicateCore-iOS-SDK.git
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
@@ -94,6 +94,6 @@ SPEC CHECKSUMS:
   ZendeskMessagingSDK: 4f5f3d43766bb3b2ea6411d1331cfe609ff33618
   ZendeskSDKConfigurationsSDK: a5c21010e17b71d02bc2cfe73dcc9da1efa0a7b2
 
-PODFILE CHECKSUM: 71488a83c7d10d1b95777caee09b684fe55dc2f2
+PODFILE CHECKSUM: 47b93066f749c895252c6f861e57197ab9ee149f
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## Summary
- Observe events -> message, attachment message, agent leave
- Added chat log logic to sync zendesk and kommunicate messages

## Tasks completed:
- When message event triggered, send message to /rest/ws/zendesk/message/send
- When attachment event triggered, send attachment to /rest/ws/zendesk/file/send
- When Agent ends chat from Zendesk, call Resolve conversation API and resolve the conversation.
- When "Restart conversation" is clicked, a new conversation is created to maintain a single chat thread.
- Handled Chat logs -> If the app is closed and opened again, it will sync the messages sent from Zendesk dashboard until session is live