### PR TITLE
[CM-1325] Hide User submitted message on form submission 

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1621,7 +1621,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         var formAction: String?
         var message: String?
         var isFormDataReplytoChat = false
-        var hiddenMessage = false
+        var actionMessageMetaData = [String:String]()
 
         for element in formTemplate.elements {
             if element.contentType == .hidden,
@@ -1650,8 +1650,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                     isFormDataReplytoChat = true
                 }
                 
-                if let metadata = action.metadata, let category =  metadata["category"] , category.uppercased() == "HIDDEN" {
-                    hiddenMessage = true
+                if let metadata = action.metadata  {
+                    actionMessageMetaData = metadata
                 }
             }
         }
@@ -1733,8 +1733,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             return
         }
         
-        if hiddenMessage {
-            chatContextData["hide"] = true
+        if !actionMessageMetaData.isEmpty {
+            chatContextData.merge(actionMessageMetaData, uniquingKeysWith: {$1})
         }
 
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1621,6 +1621,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         var formAction: String?
         var message: String?
         var isFormDataReplytoChat = false
+        var hiddenMessage = false
 
         for element in formTemplate.elements {
             if element.contentType == .hidden,
@@ -1648,6 +1649,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 if let formTemplatePostFormDataAsMessage = action.postFormDataAsMessage, formTemplatePostFormDataAsMessage == "true" {
                     isFormDataReplytoChat = true
                 }
+                hiddenMessage = action.hide
             }
         }
 
@@ -1723,10 +1725,15 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         var formJsonData = [String: Any]()
         formJsonData["formData"] = formJsonValue
 
-        guard let chatContextData = getUpdateMessageMetadata(with: formJsonData) else {
+        guard var chatContextData = getUpdateMessageMetadata(with: formJsonData) else {
             print("Failed to convert the chat context data to json")
             return
         }
+        
+        if hiddenMessage {
+            chatContextData["hide"] = true
+        }
+
 
         if isFormDataReplytoChat {
             sendPostSubmittedFormDataAsMessage(message: message, messageModel: messageModel, postFormData: postFormData, chatContextData: chatContextData)

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1649,7 +1649,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 if let formTemplatePostFormDataAsMessage = action.postFormDataAsMessage, formTemplatePostFormDataAsMessage == "true" {
                     isFormDataReplytoChat = true
                 }
-                hiddenMessage = action.hide
+                
+                if let metadata = action.metadata, let category =  metadata["category"] , category.uppercased() == "HIDDEN" {
+                    hiddenMessage = true
+                }
             }
         }
 

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -28,7 +28,7 @@ struct FormTemplate: Decodable {
 
     struct Action: Decodable {
         let formAction, message, requestType: String?, postFormDataAsMessage: String?
-        var hide: Bool = false
+        var metadata : [String:String]?
     }
 
     struct Validation: Decodable {

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -28,6 +28,7 @@ struct FormTemplate: Decodable {
 
     struct Action: Decodable {
         let formAction, message, requestType: String?, postFormDataAsMessage: String?
+        var hide: Bool = false
     }
 
     struct Validation: Decodable {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -719,9 +719,15 @@ open class ALKConversationViewModel: NSObject, Localizable {
         alMessage.message = message
         alMessage.metadata = modfiedMessageMetadata(alMessage: alMessage, metadata: metadata)
 
-        addToWrapper(message: alMessage)
-        let indexPath = IndexPath(row: 0, section: messageModels.count - 1)
-        delegate?.messageSent(at: indexPath)
+//        addToWrapper(message: alMessage)
+//        let indexPath = IndexPath(row: 0, section: messageModels.count - 1)
+//        delegate?.messageSent(at: indexPath)
+        var indexPath = IndexPath(row: 0, section: messageModels.count - 1)
+        if !alMessage.isHiddenMessage() {
+            addToWrapper(message: alMessage)
+            indexPath = IndexPath(row: 0, section: messageModels.count - 1)
+            delegate?.messageSent(at: indexPath)
+        }
         if isOpenGroup {
             let messageClientService = ALMessageClientService()
             messageClientService.sendMessage(alMessage.dictionary(), withCompletionHandler: { _, error in
@@ -731,6 +737,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 if KMZendeskChatHandler.shared.isZendeskEnabled()  {
                     KMZendeskChatHandler.shared.sendMessage(message: alMessage)
                 }
+                guard !alMessage.isHiddenMessage() else {return}
                 alMessage.status = NSNumber(integerLiteral: Int(SENT.rawValue))
                 self.messageModels[indexPath.section] = alMessage.messageModel
                 self.delegate?.updateMessageAt(indexPath: indexPath)
@@ -744,6 +751,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 if KMZendeskChatHandler.shared.isZendeskEnabled()  {
                     KMZendeskChatHandler.shared.sendMessage(message: alMessage)
                 }
+                guard !alMessage.isHiddenMessage() else {return}
                 alMessage.status = NSNumber(integerLiteral: Int(SENT.rawValue))
                 self.messageModels[indexPath.section] = alMessage.messageModel
                 self.delegate?.updateMessageAt(indexPath: indexPath)

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -719,9 +719,6 @@ open class ALKConversationViewModel: NSObject, Localizable {
         alMessage.message = message
         alMessage.metadata = modfiedMessageMetadata(alMessage: alMessage, metadata: metadata)
 
-//        addToWrapper(message: alMessage)
-//        let indexPath = IndexPath(row: 0, section: messageModels.count - 1)
-//        delegate?.messageSent(at: indexPath)
         var indexPath = IndexPath(row: 0, section: messageModels.count - 1)
         if !alMessage.isHiddenMessage() {
             addToWrapper(message: alMessage)


### PR DESCRIPTION
## Summary
- Added support to send hidden message
- Added support for metadata for Action Message on Form Template
- Added Support for hiding message on form submission based on metadata
- if metadata contains `  "category": "HIDDEN"` submission message will be hidden on user end. it will be visible on dashboard

## SS

### at user end
<img width="250" height="400"  src="https://user-images.githubusercontent.com/121929127/219360204-e9983dd5-8877-4335-82fb-065783731988.png">


### On dashboard

<img width="1440" alt="Screenshot 2023-02-16 at 5 34 09 PM" src="https://user-images.githubusercontent.com/121929127/219360226-45619c14-b6cc-4dc7-b5cc-1631c2e89ddf.png">


## Note:
 You can see` submitted my details` only visible at dashboard end not at user end
