### PR TITLE
[CM-1355] Added customisation flag for hiding chat widget on helpcenter page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## [Unreleased]
+- [CM-1365] Added Customization for hiding chat widget on helpcenter
 ## [0.3.1] - 2023-02-17
 - [CM-1188] Fixed `attempt to insert section 1 but there are only 1 sections after the update` crash
 - [CM-1278] Added Suppor rating button on conversation screen

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -186,6 +186,9 @@ public struct ALKConfiguration {
     
     /// If true, rate conversation button will be visible on ConversationVC, By default it is false.
     public var rateConversationMenuOption = false
+    
+    /// if false then chat  will be popped up on helpcenter(FAQ) page. by default it is true.
+    public var hideChatInHelpcenter: Bool = true
 
     /// If true, contact share option in chatbar will be hidden.
     @available(*, deprecated, message: "Use .chatBar.optionsToShow instead")

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -187,7 +187,7 @@ public struct ALKConfiguration {
     /// If true, rate conversation button will be visible on ConversationVC, By default it is false.
     public var rateConversationMenuOption = false
     
-    /// if false then chat  will be popped up on helpcenter(FAQ) page. by default it is true.
+    /// if false then chat  will be popped up on helpcenter(FAQ) page, By default it is true.
     public var hideChatInHelpcenter: Bool = true
 
     /// If true, contact share option in chatbar will be hidden.


### PR DESCRIPTION
## Summary
- Added Customisation flag `hideChatInHelpcenter` to hide/show the chat widget on helpcenter/FAQ page