### PR TITLE
Fixed Build Issue on SPM  Integration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
+## [Unreleased]
+- Fixed build issue when sdk integrated thorugh SPM
 ## [1.0.0] - 2023-03-09
 - Fixed conversationClient Id setting issue
-- Update packages 
+- Updated packages 
 ## [0.3.1] - 2023-02-17
 - [CM-1188] Fixed `attempt to insert section 1 but there are only 1 sections after the update` crash
 - [CM-1278] Added Suppor rating button on conversation screen

--- a/Demo/KommunicateChatUI-iOS-SDK-Demo.xcodeproj/project.pbxproj
+++ b/Demo/KommunicateChatUI-iOS-SDK-Demo.xcodeproj/project.pbxproj
@@ -528,11 +528,6 @@
 				"${BUILT_PRODUCTS_DIR}/KommunicateCore-iOS-SDK/KommunicateCore_iOS_SDK.framework",
 				"${BUILT_PRODUCTS_DIR}/SwipeCellKit/SwipeCellKit.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskChatProvidersSDK/ChatProvidersSDK.framework/ChatProvidersSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskChatSDK/ChatSDK.framework/ChatSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskCommonUISDK/CommonUISDK.framework/CommonUISDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskMessagingAPISDK/MessagingAPI.framework/MessagingAPI",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskMessagingSDK/MessagingSDK.framework/MessagingSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskSDKConfigurationsSDK/SDKConfigurations.framework/SDKConfigurations",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -541,11 +536,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KommunicateCore_iOS_SDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwipeCellKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatProvidersSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonUISDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingAPI.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDKConfigurations.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -607,11 +597,6 @@
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
 				"${BUILT_PRODUCTS_DIR}/iOSSnapshotTestCase/FBSnapshotTestCase.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskChatProvidersSDK/ChatProvidersSDK.framework/ChatProvidersSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskChatSDK/ChatSDK.framework/ChatSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskCommonUISDK/CommonUISDK.framework/CommonUISDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskMessagingAPISDK/MessagingAPI.framework/MessagingAPI",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskMessagingSDK/MessagingSDK.framework/MessagingSDK",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskSDKConfigurationsSDK/SDKConfigurations.framework/SDKConfigurations",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -624,11 +609,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatProvidersSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonUISDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingAPI.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDKConfigurations.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -12,8 +12,7 @@ PODS:
     - KommunicateChatUI-iOS-SDK/RichMessageKit
     - KommunicateCore-iOS-SDK (~> 1.0.7)
     - SwipeCellKit (~> 2.7.1)
-    - ZendeskChatProvidersSDK
-    - ZendeskChatSDK
+    - ZendeskChatProvidersSDK (~> 3.0.0)
   - KommunicateChatUI-iOS-SDK/RichMessageKit (1.0.0)
   - KommunicateCore-iOS-SDK (1.0.7)
   - Nimble (10.0.0)
@@ -27,16 +26,6 @@ PODS:
   - SwiftLint (0.50.3)
   - SwipeCellKit (2.7.1)
   - ZendeskChatProvidersSDK (3.0.0)
-  - ZendeskChatSDK (3.0.0):
-    - ZendeskChatProvidersSDK (= 3.0.0)
-    - ZendeskMessagingSDK (= 4.0.0)
-  - ZendeskCommonUISDK (7.0.0)
-  - ZendeskMessagingAPISDK (4.0.0):
-    - ZendeskSDKConfigurationsSDK (= 2.0.0)
-  - ZendeskMessagingSDK (4.0.0):
-    - ZendeskCommonUISDK (= 7.0.0)
-    - ZendeskMessagingAPISDK (= 4.0.0)
-  - ZendeskSDKConfigurationsSDK (2.0.0)
 
 DEPENDENCIES:
   - KommunicateChatUI-iOS-SDK (from `../KommunicateChatUI-iOS-SDK.podspec`)
@@ -58,11 +47,6 @@ SPEC REPOS:
     - SwiftLint
     - SwipeCellKit
     - ZendeskChatProvidersSDK
-    - ZendeskChatSDK
-    - ZendeskCommonUISDK
-    - ZendeskMessagingAPISDK
-    - ZendeskMessagingSDK
-    - ZendeskSDKConfigurationsSDK
 
 EXTERNAL SOURCES:
   KommunicateChatUI-iOS-SDK:
@@ -71,7 +55,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kingfisher: 5efc54fec3980f92354898532e562cc17f31efb4
-  KommunicateChatUI-iOS-SDK: f9db6bc4ab73c3857c9e3f91f4399788263d2c91
+  KommunicateChatUI-iOS-SDK: dde1a67b1fcbe15a84b362e534da48d059db6a8d
   KommunicateCore-iOS-SDK: dbcd925238d785a45181d03353a011e3634b23f9
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Nimble-Snapshots: ef281b908c604f78c8313587e25ea92c8ab513d7
@@ -80,11 +64,6 @@ SPEC CHECKSUMS:
   SwiftLint: 77f7cb2b9bb81ab4a12fcc86448ba3f11afa50c6
   SwipeCellKit: 3972254a826da74609926daf59b08d6c72e619ea
   ZendeskChatProvidersSDK: af93e02e2058875f92e6ad86e74ee51203b4079e
-  ZendeskChatSDK: fe03650a5ebe3d35fd1f4da90792021f809bcf11
-  ZendeskCommonUISDK: f06dbac6c9e74c3afff75ecdc6bec3832b23258c
-  ZendeskMessagingAPISDK: 95a99f1eab9482b4106ec88466b93a89f9f7c5fa
-  ZendeskMessagingSDK: 4f5f3d43766bb3b2ea6411d1331cfe609ff33618
-  ZendeskSDKConfigurationsSDK: a5c21010e17b71d02bc2cfe73dcc9da1efa0a7b2
 
 PODFILE CHECKSUM: ceb862bddf2e495511834b44350239c68ccce94f
 

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -23,8 +23,7 @@ Pod::Spec.new do |s|
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
     complete.dependency 'Kingfisher', '~> 7.0.0'
     complete.dependency 'SwipeCellKit', '~> 2.7.1'
-    complete.dependency 'ZendeskChatProvidersSDK'
-    complete.dependency 'ZendeskChatSDK'
+    complete.dependency 'ZendeskChatProvidersSDK',  '~> 3.0.0'
     complete.dependency 'KommunicateCore-iOS-SDK', '~> 1.0.7'
     complete.dependency 'KommunicateChatUI-iOS-SDK/RichMessageKit'
   end

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "ZendeskChatProvidersSDK",
+        "repositoryURL": "https://github.com/zendesk/chat_providers_sdk_ios",
+        "state": {
+          "branch": null,
+          "revision": "60db4a62dd2ec0c4cbc213b869c7df199b910ab1",
+          "version": "3.0.0"
+        }
+      },
+      {
         "package": "Kingfisher",
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,15 @@ let package = Package(
         .package(name: "KommunicateCore_iOS_SDK", url: "https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git", from: "1.0.7"),
         .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", .exact("7.0.0")),
         .package(name: "SwipeCellKit", url: "https://github.com/SwipeCellKit/SwipeCellKit.git", from: "2.7.1"),
+        .package(name: "ZendeskChatProvidersSDK", url: "https://github.com/zendesk/chat_providers_sdk_ios",.exact("3.0.0")),
     ],
     targets: [
         .target(name: "KommunicateChatUI-iOS-SDK",
                 dependencies: ["RichMessageKit",
                                .product(name: "KommunicateCore_iOS_SDK", package: "KommunicateCore_iOS_SDK"),
                                "Kingfisher",
-                               "SwipeCellKit"],
+                               "SwipeCellKit",
+                               "ZendeskChatProvidersSDK"],
                 path: "Sources",
                 exclude: ["Extras"],
                 linkerSettings: [

--- a/Sources/Utilities/KMZendeskChatHandler.swift
+++ b/Sources/Utilities/KMZendeskChatHandler.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import ChatSDK
 import ChatProvidersSDK
 import KommunicateCore_iOS_SDK
 

--- a/Sources/Utilities/UIApplication+Extension.swift
+++ b/Sources/Utilities/UIApplication+Extension.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 @available(iOSApplicationExtension, unavailable, message: "UIApplication.shared is unavailable in application extensions")
 public extension UIApplication {


### PR DESCRIPTION
## Summary
- Zendesk dependency was not added on Package.swift.So its creating problem when Kommunicate sdk integrated via SPM.
- Removed extra libraries added by zendesk pack. integrated required chatproviders in pod as well as package.

## Testing
- Tested by adding this  in sample app by SPM.