### PR TITLE
updated kingfisher pod

### DIFF
--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -4,11 +4,11 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kingfisher (7.0.0)
+  - Kingfisher (7.6.2)
   - KommunicateChatUI-iOS-SDK (1.0.4):
     - KommunicateChatUI-iOS-SDK/Complete (= 1.0.4)
   - KommunicateChatUI-iOS-SDK/Complete (1.0.4):
-    - Kingfisher (~> 7.0.0)
+    - Kingfisher (~> 7.6.2)
     - KommunicateChatUI-iOS-SDK/RichMessageKit
     - KommunicateCore-iOS-SDK (~> 1.0.8)
     - SwipeCellKit (~> 2.7.1)
@@ -54,8 +54,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kingfisher: 5efc54fec3980f92354898532e562cc17f31efb4
-  KommunicateChatUI-iOS-SDK: 3c4a4f7c07937bfddb8b244a0ee3add9442471f2
+  Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
+  KommunicateChatUI-iOS-SDK: 0186ce248db0d36f91b3cd9138e86f4b0334b618
   KommunicateCore-iOS-SDK: 69f611a6377424b5253a9650c654bb67921f11ff
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Nimble-Snapshots: ef281b908c604f78c8313587e25ea92c8ab513d7

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.subspec 'Complete' do |complete|
     complete.source_files = 'Sources/**/*.swift'
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
-    complete.dependency 'Kingfisher', '~> 7.0.0'
+    complete.dependency 'Kingfisher', '~> 7.6.2'
     complete.dependency 'SwipeCellKit', '~> 2.7.1'
     complete.dependency 'ZendeskChatProvidersSDK',  '~> 3.0.0'
     complete.dependency 'KommunicateCore-iOS-SDK', '~> 1.0.8'

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "8c65ddf756c633d01d9ae01092bf72f0c66dfc60",
-          "version": "7.0.0"
+          "revision": "af4be924ad984cf4d16f4ae4df424e79a443d435",
+          "version": "7.6.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "KommunicateCore_iOS_SDK", url: "https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git", from: "1.0.8"),
-        .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", .exact("7.0.0")),
+        .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", .exact("7.6.2")),
         .package(name: "SwipeCellKit", url: "https://github.com/SwipeCellKit/SwipeCellKit.git", from: "2.7.1"),
         .package(name: "ZendeskChatProvidersSDK", url: "https://github.com/zendesk/chat_providers_sdk_ios",.exact("3.0.0")),
     ],


### PR DESCRIPTION
## Summary
- Current Chat UI is contains Kingfisher(v-7.0.0) sub pod. But kingfisher library has creating build [issue](https://github.com/onevcat/Kingfisher/pull/2029) on Xcode 14.2. This issue was fixed on version[ 7.6.1](https://github.com/onevcat/Kingfisher/releases/tag/7.6.1). So pointing to the latest version of kingfisher

## Testing
- Tested all the instances(40 places) of kingfisher usage in our sdk.