### PR TITLE
[CM-1415] Form Template Submission Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 ## [Unreleased]
 - Added Support for delete conversation for End User
-
+- Fixed Form text area data not added with message for `postFormDataAsMessage` issue
+- Matched form action flow with web & android.
+- Fixed submitted form data double stringified issue
 ## [1.0.5] - 2023-04-05
 - Upgraded Kingfisher pod to version 7.6.2
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1766,8 +1766,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 selectedArray.append(value)
             }
 
-            let data = json(from: selectedArray)
-            postFormData[multiSelect.name] = data
+            postFormData[multiSelect.name] = selectedArray
         }
 
         for (position, timeInMillSecs) in formData.dateFields {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1602,6 +1602,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
         group.notify(queue: .main) {
             self.activityIndicator.stopAnimating()
+            guard self.configuration.pushWebviewWithFormActionResponse else {return}
             guard let data = responseData, let url = responseUrl else {
                 return
             }
@@ -1724,6 +1725,28 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 break
             }
         }
+        
+        for (pos, text) in formData.textViews {
+            let element = viewModelItems[pos]
+            switch element.type {
+            case .text:
+                if let textModel = element as? FormViewModelTextItem {
+                    postFormData[textModel.label] = text
+                }
+            case .textarea:
+                if let textModel = element as? FormViewModelTextAreaItem {
+                    postFormData[textModel.title] = text
+                }
+            case .password:
+                if let passwordModel = element as? FormViewModelPasswordItem {
+                    postFormData[passwordModel.label] = text
+                }
+            default:
+                break
+            }
+        }
+        
+        
 
         for (section, pos) in formData.singleSelectFields {
             guard let singleSelectModel = viewModelItems[section] as? FormViewModelSingleselectItem else {
@@ -1768,12 +1791,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             }
         }
 
-        guard let formJsonValue = ALUtilityClass.generateJsonString(from: postFormData) else {
-            print("Failed to convert the formdata to json")
-            return
-        }
         var formJsonData = [String: Any]()
-        formJsonData["formData"] = formJsonValue
+        formJsonData["formData"] = postFormData
 
         guard var chatContextData = getUpdateMessageMetadata(with: formJsonData) else {
             print("Failed to convert the chat context data to json")
@@ -1784,38 +1803,35 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             chatContextData.merge(actionMessageMetaData, uniquingKeysWith: {$1})
         }
 
-
         if isFormDataReplytoChat {
             sendPostSubmittedFormDataAsMessage(message: message, messageModel: messageModel, postFormData: postFormData, chatContextData: chatContextData)
 
-        } else {
-            if let messageString = message {
-                viewModel.send(message: messageString, metadata: chatContextData)
-            }
-            guard
-                let urlString = formAction,
-                let url = URL(string: urlString)
-            else {
-                print("URL for posting is not valid")
-                return
-            }
-            var request: URLRequest!
-            guard let jsonData = try? JSONSerialization.data(withJSONObject: chatContextData),
-                  let jsonString = String(data: jsonData, encoding: .utf8),
-                  let data = jsonString.data(using: .utf8),
-                  let urlRequest = postRequestUsing(url: url, data: data)
-            else { return }
+        } else if let messageString = message {
+            viewModel.send(message: messageString, metadata: chatContextData)
+        }
+            
+        guard let urlString = formAction,
+            let url = URL(string: urlString)
+        else {
+            print("URL for posting is not valid")
+            return
+        }
+        var request: URLRequest!
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: postFormData),
+              let jsonString = String(data: jsonData, encoding: .utf8),
+              let data = jsonString.data(using: .utf8),
+              let urlRequest = postRequestUsing(url: url, data: data)
+        else { return }
 
-            request = urlRequest
-            if requestType == "json" {
-                let contentType = "application/json"
-                request.addValue(contentType, forHTTPHeaderField: "Content-Type")
-                requestHandler(request) { _, _, _ in }
-            } else {
-                let contentType = "application/x-www-form-urlencoded"
-                request.addValue(contentType, forHTTPHeaderField: "Content-Type")
-                submitButtonResponse(request: request)
-            }
+        request = urlRequest
+        if requestType == "json" {
+            let contentType = "application/json"
+            request.addValue(contentType, forHTTPHeaderField: "Content-Type")
+            requestHandler(request) { _, _, _ in }
+        } else {
+            let contentType = "application/x-www-form-urlencoded"
+            request.addValue(contentType, forHTTPHeaderField: "Content-Type")
+            submitButtonResponse(request: request)
         }
     }
 
@@ -1842,6 +1858,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             case .password:
                 if let passwordItemModel = item as? FormViewModelPasswordItem {
                     postBackMessageString.append("\(passwordItemModel.label) : \(postFormData[passwordItemModel.label] ?? "")\n")
+                }
+            case.textarea:
+                if let textAreaModelItem = item as? FormViewModelTextAreaItem {
+                    postBackMessageString.append("\(textAreaModelItem.title) : \(postFormData[textAreaModelItem.title] ?? "")\n")
                 }
             case .singleselect:
                 if let singleSelectionItemModel = item as? FormViewModelSingleselectItem {

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -197,6 +197,10 @@ public struct ALKConfiguration {
     
     /// if true then delete option will be enabled for end user on long press, By default it is false
     public var enableDeleteConversationOnLongpress : Bool = false
+    
+    /// if true then webview will be pushed once formaction url returns with response, By default it is false
+    public var pushWebviewWithFormActionResponse = false
+
 
     /// If true, contact share option in chatbar will be hidden.
     @available(*, deprecated, message: "Use .chatBar.optionsToShow instead")


### PR DESCRIPTION
## Summary
- Fixed Form submitted data double stringified on Api and matched with web, android sdk by removing kmchatcontext in the request data
- Added support to  Form action & postformdataasmessage at the same time
- Added customisation for pushing web view after receiving response from formation url.
- 
## Before fix
<img src = "https://user-images.githubusercontent.com/121929127/233007048-73f0477a-6af1-4fdb-96f5-aa1ff5e6340c.png" width = 1000 height = 500 />

## After fix
<img src = "https://user-images.githubusercontent.com/121929127/233007982-f3495ac3-9d0a-48fb-877c-9d8c79399e55.png" width = 1000 height = 500 />

<img src = "https://user-images.githubusercontent.com/121929127/233009353-7a2949a3-f759-4fe1-93a6-f5edb3dc1dcc.png" width = 1000 height = 500 />






