### PR TITLE
Added support for restriction for attachment based on size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 
 ##[Unreleased]
 - [CM-1444] Added custom cloud support for attachments
+- [CM-1469] Added restrction attachment upload size
 ## [1.0.7] 2023-04-28
 - Fixed Event data not getting passed for Rich Message Event
 ## [1.0.6] 2023-04-19

--- a/Sources/Controllers/ALKConversationViewController+DocumentManager.swift
+++ b/Sources/Controllers/ALKConversationViewController+DocumentManager.swift
@@ -10,6 +10,12 @@ import UIKit
 
 extension ALKConversationViewController: ALKDocumentManagerDelegate {
     func documentSelected(at url: URL, fileName: String) {
+        // We are getting file size in KB
+        if let size = FileManager().sizeOfFile(atPath: url.path), size > (ALApplozicSettings.getMaxImageSizeForUploadInMB() * 1024) {
+            showUploadRestrictionAlert()
+            return
+        }
+
         let (message, indexPath) = viewModel.sendFile(
             at: url,
             fileName: fileName,

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2266,6 +2266,22 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             self.navigationBar.updateView(profile: profile)
         }
     }
+    
+    func showUploadRestrictionAlert() {
+        let uploadrestrictionTitle = self.localizedString(
+            forKey: "uploadRestrictionTitle",
+            withDefaultValue: SystemMessage.Warning.uploadAttachmentRestrictionTitle,
+            fileName: self.localizedStringFileName
+        )
+        
+        let uploadrestrictionMessage = self.localizedString(
+            forKey: "uploadRestrcitionMessage",
+            withDefaultValue: SystemMessage.Warning.uploadAttachmentRestrictionMessage,
+            fileName: self.localizedStringFileName
+        )
+       
+        self.showAlert(alertTitle: uploadrestrictionTitle, alertMessage: uploadrestrictionMessage)
+    }
 }
 
 extension ALKConversationViewController: ALKCreateGroupChatAddFriendProtocol {
@@ -2529,6 +2545,12 @@ extension ALKConversationViewController: ALKCustomPickerDelegate {
         for index in 0 ..< fileCount {
             if index < images.count {
                 let image = images[index]
+                guard image.getSizeInMb() < Double(ALApplozicSettings.getMaxImageSizeForUploadInMB()) else{
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: {
+                        self.showUploadRestrictionAlert()
+                    })
+                    continue
+                }
                 let (message, indexPath) = viewModel.send(
                     photo: image,
                     metadata: configuration.messageMetadata
@@ -2549,6 +2571,13 @@ extension ALKConversationViewController: ALKCustomPickerDelegate {
                 viewModel.uploadImage(view: cell, indexPath: newIndexPath)
             } else {
                 let path = videos[index - images.count]
+                
+                if let size = FileManager().sizeOfFile(atPath: path), size > ALApplozicSettings.getMaxImageSizeForUploadInMB() {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: {
+                        self.showUploadRestrictionAlert()
+                    })
+                    continue
+                }
                 guard let indexPath = viewModel.sendVideo(
                     atPath: path,
                     sourceType: .photoLibrary,

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2275,7 +2275,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         )
         
         let uploadrestrictionMessage = self.localizedString(
-            forKey: "uploadRestrcitionMessage",
+            forKey: "uploadRestrictionMessage",
             withDefaultValue: SystemMessage.Warning.uploadAttachmentRestrictionMessage,
             fileName: self.localizedStringFileName
         )

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -176,3 +176,6 @@ DeleteConversationTitle = "Delete Conversation";
 DeleteConversationContent = "Do you want to delete the conversation?";
 DeleteConversationSuccessMessage = "Successfully deleted the conversation!!!";
 DeleteConversationFailureMessage = "Failed to delete the conversation!!!";
+/* upload Max size  restriction messages */
+uploadRestrictionTitle = "Large File";
+uploadRestrcitionMessage = "Itseems uploading file size is larger than the limit.";

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -177,5 +177,5 @@ DeleteConversationContent = "Do you want to delete the conversation?";
 DeleteConversationSuccessMessage = "Successfully deleted the conversation!!!";
 DeleteConversationFailureMessage = "Failed to delete the conversation!!!";
 /* upload Max size  restriction messages */
-uploadRestrictionTitle = "Large File";
-uploadRestrcitionMessage = "Itseems uploading file size is larger than the limit.";
+uploadRestrictionTitle = "File Too Big!!";
+uploadRestrcitionMessage = "Looks like the file you are trying to upload is too big.";

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -178,4 +178,4 @@ DeleteConversationSuccessMessage = "Successfully deleted the conversation!!!";
 DeleteConversationFailureMessage = "Failed to delete the conversation!!!";
 /* upload Max size  restriction messages */
 uploadRestrictionTitle = "File Too Big!!";
-uploadRestrcitionMessage = "Looks like the file you are trying to upload is too big.";
+uploadRestrictionMessage = "Looks like the file you are trying to upload is too big.";

--- a/Sources/Utilities/ALKFileUtils.swift
+++ b/Sources/Utilities/ALKFileUtils.swift
@@ -101,3 +101,12 @@ class ALKFileUtils: NSObject {
         return filePath
     }
 }
+
+extension FileManager {
+    func sizeOfFile(atPath path: String) -> Int64? {
+        guard let attrs = try? attributesOfItem(atPath: path), let size = attrs[.size] as? Int64  else {
+            return nil
+        }
+       return size/1024
+    }
+}

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -84,6 +84,8 @@ struct SystemMessage: Localizable {
         static let profaneWordsTitle = localizedString(forKey: "profaneWordsTitle")
         static let profaneWordsMessage = localizedString(forKey: "profaneWordsMessage")
         static let videoExportError = localizedString(forKey: "VideoExportError")
+        static let uploadAttachmentRestrictionTitle = localizedString(forKey: "uploadRestrictionTitle")
+        static let uploadAttachmentRestrictionMessage = localizedString(forKey: "uploadRestrcitionMessage")
     }
 
     enum ButtonName {

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -85,7 +85,7 @@ struct SystemMessage: Localizable {
         static let profaneWordsMessage = localizedString(forKey: "profaneWordsMessage")
         static let videoExportError = localizedString(forKey: "VideoExportError")
         static let uploadAttachmentRestrictionTitle = localizedString(forKey: "uploadRestrictionTitle")
-        static let uploadAttachmentRestrictionMessage = localizedString(forKey: "uploadRestrcitionMessage")
+        static let uploadAttachmentRestrictionMessage = localizedString(forKey: "uploadRestrictionMessage")
     }
 
     enum ButtonName {


### PR DESCRIPTION
## Summary
- Added support for restriction  upload attachments based on size. By default it is 25 MB. it can be customized based by using below code
```
ALApplozicSettings.setMaxImageSizeForUploadInMB(6)

```

you should import communicate core module whenever you use this customisation like this `import KommunicateCore_iOS_SDK`

 