### PR TITLE
[CM-1479] Fixed upload issue

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1409,7 +1409,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         ALKCustomEventHandler.shared.publish(triggeredEvent: CustomEvent.richMessageClick, data:  ["conversationId":viewModel.channelKey?.stringValue,"action": action , "type": type])
         switch type {
         case ActionType.link.rawValue:
-            guard let urlString = action.url, let url = URL(string: urlString) else { return }
+            guard let urlString = action.url, let url = URL(string: urlString), !configuration.restrictLinkNavigationOnListTemplateTap else { return }
             openLink(url)
 
         case ActionType.quickReply.rawValue:

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -200,6 +200,9 @@ public struct ALKConfiguration {
     
     /// if true then webview will be pushed once formaction url returns with response, By default it is false
     public var pushWebviewWithFormActionResponse = false
+    
+    /// If true then on tap of list template(link) browser will not be opened. By default it is false
+    public var restrictLinkNavigationOnListTemplateTap = false
 
 
     /// If true, contact share option in chatbar will be hidden.

--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -191,12 +191,22 @@ class ALKHTTPManager: NSObject {
                     body.append(String(format: "Content-Type:%@\r\n\r\n", task.contentType ?? "").data(using: .utf8)!)
                     body.append(data)
                     body.append(String(format: "\r\n").data(using: .utf8)!)
+//                    body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
+
                 }
-                body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
+//                body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
                 
                 
                 if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
-                    body.append(String(format: "%@\n",  ["groupId": task.groupdId]).data(using: .utf8)!)
+                    body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
+                    
+                    body.append(String(format: "Content-Disposition: form-data; name=\"%@\";\r\n",  "data").data(using: .utf8)!)
+
+//                    body.append(String(format: "Content-Disposition: form-data; name=\"data\";\n" ).data(using: .utf8)!)
+                    body.append(String(format: "Content-Type:%@\r\n\r\n", "application/json").data(using: .utf8)!)
+
+//                    body.append(String(format: "Content-Type: application/json\n\n").data(using: .utf8)!)
+                    body.append(String(format: "{\"groupId\": \"%@\"}\r\n",task.groupdId ?? "").data(using: .utf8)!)
                     body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
                 }
                 

--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -191,24 +191,17 @@ class ALKHTTPManager: NSObject {
                     body.append(String(format: "Content-Type:%@\r\n\r\n", task.contentType ?? "").data(using: .utf8)!)
                     body.append(data)
                     body.append(String(format: "\r\n").data(using: .utf8)!)
-//                    body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
-
                 }
-//                body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
-                
+               
                 
                 if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
                     body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
-                    
                     body.append(String(format: "Content-Disposition: form-data; name=\"%@\";\r\n",  "data").data(using: .utf8)!)
-
-//                    body.append(String(format: "Content-Disposition: form-data; name=\"data\";\n" ).data(using: .utf8)!)
                     body.append(String(format: "Content-Type:%@\r\n\r\n", "application/json").data(using: .utf8)!)
-
-//                    body.append(String(format: "Content-Type: application/json\n\n").data(using: .utf8)!)
                     body.append(String(format: "{\"groupId\": \"%@\"}\r\n",task.groupdId ?? "").data(using: .utf8)!)
-                    body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
                 }
+                
+                body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
                 
                 request.httpBody = body
                 request.url = task.url
@@ -319,3 +312,4 @@ extension ALKHTTPManager: URLSessionDataDelegate {
         }
     }
 }
+

--- a/Sources/Utilities/ALKVideoUploadManager.swift
+++ b/Sources/Utilities/ALKVideoUploadManager.swift
@@ -131,26 +131,14 @@ class ALKVideoUploadManager: NSObject {
              body.append(String(format: "\r\n").data(using: .utf8)!)
          }
 
-        body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
-
-//        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
-//            body.append(String(format: "%@\n",  ["groupId": groupId]).data(using: .utf8)!)
-//            body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
-//        }
-        
         if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
             body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
-            
             body.append(String(format: "Content-Disposition: form-data; name=\"%@\";\r\n",  "data").data(using: .utf8)!)
-
-//                    body.append(String(format: "Content-Disposition: form-data; name=\"data\";\n" ).data(using: .utf8)!)
             body.append(String(format: "Content-Type:%@\r\n\r\n", "application/json").data(using: .utf8)!)
-
-//                    body.append(String(format: "Content-Type: application/json\n\n").data(using: .utf8)!)
             body.append(String(format: "{\"groupId\": \"%@\"}\r\n",groupId ?? "").data(using: .utf8)!)
-            body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
         }
-        
+        body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
+
         urlRequest.httpBody = body
         urlRequest.url = uploadTask?.url
         return urlRequest
@@ -246,3 +234,4 @@ extension ALKVideoUploadManager: URLSessionDataDelegate {
         }
     }
 }
+

--- a/Sources/Utilities/ALKVideoUploadManager.swift
+++ b/Sources/Utilities/ALKVideoUploadManager.swift
@@ -133,8 +133,21 @@ class ALKVideoUploadManager: NSObject {
 
         body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
 
+//        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
+//            body.append(String(format: "%@\n",  ["groupId": groupId]).data(using: .utf8)!)
+//            body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
+//        }
+        
         if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
-            body.append(String(format: "%@\n",  ["groupId": groupId]).data(using: .utf8)!)
+            body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
+            
+            body.append(String(format: "Content-Disposition: form-data; name=\"%@\";\r\n",  "data").data(using: .utf8)!)
+
+//                    body.append(String(format: "Content-Disposition: form-data; name=\"data\";\n" ).data(using: .utf8)!)
+            body.append(String(format: "Content-Type:%@\r\n\r\n", "application/json").data(using: .utf8)!)
+
+//                    body.append(String(format: "Content-Type: application/json\n\n").data(using: .utf8)!)
+            body.append(String(format: "{\"groupId\": \"%@\"}\r\n",groupId ?? "").data(using: .utf8)!)
             body.append(String(format: "--%@--\r\n", boundary).data(using: .utf8)!)
         }
         

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -228,6 +228,11 @@ extension ALMessage {
             }
             return .email
         }
+        
+        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty && Int32(contentType) == ALMESSAGE_CONTENT_ATTACHMENT {
+            return richMessageType()
+        }
+        
         switch Int32(contentType) {
         case ALMESSAGE_CONTENT_DEFAULT:
             return richMessageType()
@@ -389,6 +394,8 @@ extension ALMessage {
                 return .text
             case ALMESSAGE_CONTENT_TEXT_HTML:
                 return .html
+            case ALMESSAGE_CONTENT_ATTACHMENT:
+                return getAttachmentType() ?? .text
             default:
                 return .text
             }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -919,9 +919,6 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
 
         message.status = NSNumber(integerLiteral: Int(SENT.rawValue))
-        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
-            message.contentType = 0
-        }
         
         let error = alHandler?.saveContext()
         if error != nil {


### PR DESCRIPTION
## Summary
- Fixed upload issue taxbuddy server was not able to detect the group id and hence uploading docs are not routed correctly on their side
- Added a flag to to restrict opening browser when link list template item tapped
- Media event is not getting triggered from the server due to content type.Fixed it by changing the content type to 1(attachment) and handled it in the UI