### PR TITLE
[CM-1451] Fixed template message view issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## [Unreleased]
+- [CM-1451] Fixed issue in ALKTemplateMessage flow 
 ## [1.0.9] 2023-06-07
 - Added Customization to restrict browser navigation on tap of link list template
 - Fixed the upload issue for custom cloud support

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -429,12 +429,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         viewModel.delegate = self
         refreshViewController()
 
-        if let templates = viewModel.getMessageTemplates() {
-            templateView = ALKTemplateMessagesView(frame: CGRect.zero, viewModel: ALKTemplateMessagesViewModel(messageTemplates: templates))
-        }
-        templateView?.messageSelected = { [weak self] template in
-            self?.viewModel.selected(template: template, metadata: self?.configuration.messageMetadata)
-        }
         if isFirstTime {
             setupView()
         } else {
@@ -448,6 +442,15 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     override open func viewDidLoad() {
         super.viewDidLoad()
+       
+        if let templates = viewModel.getMessageTemplates() {
+            templateView = ALKTemplateMessagesView(frame: CGRect.zero, viewModel: ALKTemplateMessagesViewModel(messageTemplates: templates))
+        }
+        
+        templateView?.messageSelected = { [weak self] template in
+            self?.viewModel.selected(template: template, metadata: self?.configuration.messageMetadata)
+        }
+        
         setupConstraints()
         setRichMessageKitTheme()
         setupProfanityFilter()

--- a/Sources/Views/ALKTemplateMessagesView.swift
+++ b/Sources/Views/ALKTemplateMessagesView.swift
@@ -93,4 +93,20 @@ extension ALKTemplateMessagesView: UICollectionViewDelegate, UICollectionViewDat
     public func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return viewModel.getSizeForItemAt(row: indexPath.row)
     }
+    
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+            // Centering if there are fever pages
+            let itemSize: CGSize? = (collectionViewLayout as? UICollectionViewFlowLayout)?.itemSize
+            let spacing: CGFloat? = (collectionViewLayout as? UICollectionViewFlowLayout)?.minimumLineSpacing
+            let count: Int = self.collectionView(self.collectionView, numberOfItemsInSection: section)
+            let totalCellWidth = (itemSize?.width ?? 0.0) * CGFloat(count)
+            let totalSpacingWidth = (spacing ?? 0.0) * CGFloat(((count - 1) < 0 ? 0 : count - 1))
+            let leftInset: CGFloat = (bounds.size.width - (totalCellWidth + totalSpacingWidth)) / 2
+            if leftInset < 0, let inset = (collectionViewLayout as? UICollectionViewFlowLayout)?.sectionInset as? UIEdgeInsets {
+                return inset
+            }
+            let rightInset: CGFloat = leftInset
+            let sectionInset = UIEdgeInsets(top: 0, left: CGFloat(leftInset), bottom: 0, right: CGFloat(rightInset))
+            return sectionInset
+        }
 }


### PR DESCRIPTION
## Summary
- Fixed Template Message views issue
- Moved template button to centre of the screen

## SS
<img src ="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/1d9d674d-76c3-4b93-8f31-01d1855ef00a" width = 250 height = 400/> 
