### PR TITLE
[CM-1505] Added Cutstomization for send button, Template Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## [Unreleased]
+- Added Customization for Template Message
+- Added Color Customization for send button on conversation screen
 ## [1.1.0] 2023-06-30
 - Added Cusotmization support for Faq button
 - Added Support for Dropdown field in Form Template

--- a/Sources/Models/ALKChatBarConfiguration.swift
+++ b/Sources/Models/ALKChatBarConfiguration.swift
@@ -33,6 +33,9 @@ public struct ALKChatBarConfiguration {
 
     /// If true then button tint color will be disabled for attachment buttons, send button.
     public var disableButtonTintColor = false
+    
+    ///  If you set a color here then send button's tint color will be overridden by this color instead primary color.
+    public var sendButtonTintColor: UIColor? = nil
 
     /// Set the maximum number of photos/videos that can be selected in the new photos UI.
     /// Maximum limit should be less than 30

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -355,15 +355,22 @@ open class ALKChatBar: UIView, Localizable {
         let buttonTintColor = appSettingsUserDefaults.getAttachmentIconsTintColor()
         setupAttachment(buttonIcons: chatBarConfiguration.attachmentIcons, tintColor: buttonTintColor)
         setupConstraints()
-        micButton.setButtonTintColor(color: buttonTintColor)
+        // To override Primary color being set as the tint color
+        if let tintColor = chatBarConfiguration.sendButtonTintColor {
+            micButton.setButtonTintColor(color: tintColor)
+        } else {
+            micButton.setButtonTintColor(color: buttonTintColor)
+        }
+        
         var image = configuration.sendMessageIcon
         image = image?.imageFlippedForRightToLeftLayoutDirection()
         if !chatBarConfiguration.disableButtonTintColor {
             image = image?.withRenderingMode(.alwaysTemplate)
-            sendButton.imageView?.tintColor = buttonTintColor
+            // To override Primary color being set as the tint color
+            sendButton.imageView?.tintColor = chatBarConfiguration.sendButtonTintColor == nil ? buttonTintColor : chatBarConfiguration.sendButtonTintColor
         }
         sendButton.setImage(image, for: .normal)
-
+        
         if configuration.hideLineImageFromChatBar {
             lineImageView.isHidden = true
         }

--- a/Sources/Views/ALKTemplateMessageCell.swift
+++ b/Sources/Views/ALKTemplateMessageCell.swift
@@ -8,15 +8,25 @@
 import UIKit
 
 open class ALKTemplateMessageCell: UICollectionViewCell {
+    // ALKTemplateMessageCell Can be customized via this.
+    public enum Style {
+        public static var borderColor : UIColor = UIColor.blue
+        public static var textColor: UIColor = UIColor.black
+        public static var cornorRadious: CGFloat = 10.0
+        public static var textSize: CGFloat = 16.0
+        public static var borderWidth: CGFloat = 1.0
+        public static var backgroundColor: UIColor = UIColor.clear
+    }
+    
     open var textLabel: UILabel = {
         let label = UILabel(frame: CGRect.zero)
-        label.textColor = UIColor.black
+        label.textColor = Style.textColor
         label.contentMode = .center
         label.numberOfLines = 1
-        label.font = Font.normal(size: 16.0).font()
+        label.font = Font.normal(size: Style.textSize).font()
         return label
     }()
-
+    
     public let leftPadding: CGFloat = 5.0
 
     override public init(frame: CGRect) {
@@ -31,10 +41,10 @@ open class ALKTemplateMessageCell: UICollectionViewCell {
 
     func setupUI() {
         layer.masksToBounds = true
-        layer.cornerRadius = 10.0
-        layer.borderWidth = 1
-        layer.borderColor = UIColor.gray.cgColor
-        backgroundColor = UIColor.clear
+        layer.cornerRadius = Style.cornorRadious
+        layer.borderWidth = Style.borderWidth
+        layer.borderColor = Style.borderColor.cgColor
+        backgroundColor = Style.backgroundColor
         addViewsForAutolayout(views: [textLabel])
 
         textLabel.topAnchor.constraint(equalTo: topAnchor).isActive = true


### PR DESCRIPTION
## Summary
- Added Customization for Send Button on Conversation Screen. By default it will be Primary color which is set from dashboard
```
Kommunicate.defaultConfiguration.chatBar.sendButtonTintColor = .cyan
```
- Added Customization for Template Message. Using below code it can be customized

```
 ALKTemplateMessageCell.Style.backgroundColor = UIColor.clear
 ALKTemplateMessageCell.Style.borderColor = UIColor.red
 ALKTemplateMessageCell.Style.textColor = UIColor.blue
 ALKTemplateMessageCell.Style.borderWidth = 2.0
```

