### PR TITLE
[CM-1454] Added Support for showing Typing Indicator while bot feching the response

### DIFF
--- a/Sources/Utilities/KMConversationScreenConfiguration.swift
+++ b/Sources/Utilities/KMConversationScreenConfiguration.swift
@@ -15,4 +15,7 @@ public enum KMConversationScreenConfiguration {
     public static var staticTopMessage: String = ""
     // If you add image here, it will be shown along with static top message.
     public static var staticTopIcon: UIImage?  = nil
+    // If true, Typing Indicator will be shown while bot fetching the response. By default its false/
+    public static var showTypingIndicatorWhileFetchingResponse: Bool = false
+
 }


### PR DESCRIPTION
## Summary
- Added support for showing typing indicator while webhook is fetching the response.
- We can't achieve this via bot delay configuration.Because delay is will be added once message/response reached the sdk on front end. 
- This will be useful when webhook itself is taking 3-4 seconds to respond .
- This can be enabled by using `KMConversationScreenConfiguration.showTypingIndicatorWhileFetchingResponse = true` . By default it is false.