### PR TITLE
[CM-1525] Change in color code of navigationOceanBlue

### DIFF
--- a/Sources/Utilities/UIColor+Extension.swift
+++ b/Sources/Utilities/UIColor+Extension.swift
@@ -84,7 +84,7 @@ public extension UIColor {
     }
 
     static func navigationOceanBlue() -> UIColor {
-        return UIColor(netHex: 0xECEFF1)
+        return UIColor(netHex: 0x0076FF)
     }
 
     static func navigationTextOceanBlue() -> UIColor {


### PR DESCRIPTION
- The issue was the colour of app bar is grey at initial registration 
![Simulator Screenshot - iPhone 14 Plus - 2023-07-17 at 13 18 22](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/26313c2e-3067-43bf-8e2d-0d7dd015a5dd)

- Previously the colour hex code for the navigationOceanBlue was  "ECEFF1"
<img width="507" alt="Screenshot 2023-07-17 at 12 41 10 PM" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/fb433e50-b9f9-465e-af7f-87c7cc213be8">

- Changed the color hex code for the navigationOceanBlue with  "0076FF"
<img width="507" alt="Screenshot 2023-07-17 at 1 46 04 PM" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/fa8a1981-e9be-40f7-a0eb-90564fe57d33">

- After changing the color its working fine
![Simulator Screenshot - iPhone 14 Pro - 2023-07-17 at 13 19 04](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/77cb2394-db12-4367-bc16-9e081e9812de)



