### PR TITLE
[CM-1523] Added support to trigger an intent when language is selected for Speech to Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## [Unreleased]
+- [CM-1523] Added Support to trigger Assignment intent when language selected for Speech to Text.
 ## [1.1.1] 2023-07-10
 - Added Customization for Template Message
 - Added Color Customization for send button on conversation screen

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -946,12 +946,15 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             controller.closeButtonTapped = {[weak self] in
                 controller.dismiss(animated: true)
             }
-            controller.languageSelected = { [weak self]languageCode in
-                guard let weakSelf = self, !languageCode.isEmpty else {
+            controller.languageSelected = { [weak self] language in
+                guard let weakSelf = self else {
                     return
                 }
-                weakSelf.chatBar.micButton .updateLanguage(code: languageCode)
-                weakSelf.addLanguageToMetadata(language: languageCode)
+                weakSelf.chatBar.micButton.updateLanguage(code: language.code)
+                weakSelf.addLanguageToMetadata(language: language.code)
+                if language.sendMessageOnClick, let message = language.messageToSend, !message.isEmpty {
+                    weakSelf.viewModel.send(message: message, metadata: weakSelf.configuration.messageMetadata)
+                }
                 controller.dismiss(animated: true)
             }
             present(controller, animated: true, completion: nil)

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -187,8 +187,8 @@ public struct ALKConfiguration {
     /// If true, rate conversation button will be visible on ConversationVC, By default it is false.
     public var rateConversationMenuOption = false
    
-   /// List of languages for speech to text. Sample format code : ["language code": "language title"]. 
-    public var languagesForSpeechToText : [String: String] = [:]
+   /// List of languages for speech to text.
+    public var languagesForSpeechToText : [KMLanguage] = []
 
     /// if false then chat  will be popped up on helpcenter(FAQ) page, By default it is true.
     public var hideChatInHelpcenter: Bool = true

--- a/Sources/Models/KMLanguage.swift
+++ b/Sources/Models/KMLanguage.swift
@@ -13,9 +13,9 @@ public struct KMLanguage {
     var sendMessageOnClick: Bool
     var messageToSend: String?
     
-    public init(name: String, code: String, sendMessageOnClick: Bool = false, messageToSend: String? = nil) {
-        self.name = name
+    public init( code: String, name: String, sendMessageOnClick: Bool = false, messageToSend: String? = nil) {
         self.code = code
+        self.name = name
         self.sendMessageOnClick = sendMessageOnClick
         self.messageToSend = messageToSend
     }

--- a/Sources/Models/KMLanguage.swift
+++ b/Sources/Models/KMLanguage.swift
@@ -1,0 +1,22 @@
+//
+//  KMLanguage.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by sathyan elangovan on 20/07/23.
+//
+
+import Foundation
+
+public struct KMLanguage {
+    var name: String
+    var code: String
+    var sendMessageOnClick: Bool
+    var messageToSend: String?
+    
+    public init(name: String, code: String, sendMessageOnClick: Bool = false, messageToSend: String? = nil) {
+        self.name = name
+        self.code = code
+        self.sendMessageOnClick = sendMessageOnClick
+        self.messageToSend = messageToSend
+    }
+}


### PR DESCRIPTION
## Summary
- Added support to trigger an intent when language is selected for speech to text
- Created KMLanguage class to use it on Multiple Language support for Speech to Text
- This is can be enabled like below

```
let langs: [KMLanguage] = [KMLanguage(code: "hi", name: "Hindi",sendMessageOnClick: true, messageToSend: "hindi"), KMLanguage(code: "en-US", name: "English"), KMLanguage(code: "zh-hans", name: "Mandarin"), KMLanguage(code: "ms", name: "Malaysian")]
// To enable it pass the list like this 
Kommunicate.defaultConfiguration.languagesForSpeechToText = langs
```

## SS
<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/7eb15a26-ec99-45b9-8af2-871a3c121073' width = 250 height = 400 />
<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/0c810757-3fa0-4686-a665-c69189703881' width = 250 height = 400 />

- You can observe after Hindi selected , a message say "Hindi" was sent and conversation assigned to Hindi bot.

