### PR TITLE
[CM-1558] Fixed down arrow coming in bottom of the screen when welcome message get rendered 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed down arrow coming in bottom of the screen when welcome message get rendered issue.
+
 ## [1.1.2] 2023-07-21
 - [CM-1496] Fixed the form submission with empty fields issue
 - [CM-1523] Added Support to trigger Assignment intent when language selected for Speech to Text.

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2137,7 +2137,8 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             isViewLoadedFromTappingOnNotification = false
         } else if tableView.isCellVisible(section: lastSectionBeforeUpdate - 1, row: 0) {
             moveTableViewToBottom(indexPath: indexPath)
-        } else if viewModel.messageModels.count > 1 { // Check if the function is called before message is added. It happens when user is added in the group.
+        } else if viewModel.messageModels.count > 1 && !tableView.isCellVisible(section: viewModel.messageModels.count - 2, row: 0){ // Check if the function is called before message is added. It happens when user is added in the group.
+            // the second condition is for checking if the message is visible in screen or its hidden in case if the message is vissible it will not allow to enter in this condition
             unreadScrollButton.isHidden = false
         }
         


### PR DESCRIPTION
## Summary

- Added a condition to check the message is visible in screen or not on basis of that the down arrow will appear 

- This issue was coming only when the bot reply time is set to 0.0 sec.
