### PR TITLE
[CM-1569] Fixed the Form Mismatch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 
 ## Unreleased
 - Fixed down arrow coming in bottom of the screen when welcome message get rendered issue.
+- Form Submit button width is corrected.
+- Added border to the form and removed paddding form the top of each cell.
 
 ## [1.1.2] 2023-07-21
 - [CM-1496] Fixed the form submission with empty fields issue

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -22,6 +22,7 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate, UI
     let itemListView = NestedCellTableView()
     var submitButton: CurvedImageButton?
     var identifier: String?
+    let formBorderColor: CGColor = UIColor(red: 230/255, green: 229/255, blue: 236/255, alpha: 1.0).cgColor
     var activeTextField: UITextField? {
         didSet {
             activeTextFieldChanged?(activeTextField)
@@ -156,6 +157,12 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate, UI
         itemListView.alwaysBounceVertical = false
         itemListView.delegate = self
         itemListView.dataSource = self
+        itemListView.layer.borderColor = formBorderColor
+        itemListView.layer.borderWidth = 1
+        itemListView.layer.cornerRadius = 5
+        if #available(iOS 15.0, *) {  /// this is to remove the extra top padding form the cell
+            itemListView.sectionHeaderTopPadding = 0
+        }
         itemListView.tableFooterView = UIView(frame: .zero)
         itemListView.register(ALKFormItemHeaderView.self)
         itemListView.register(ALKFormTextItemCell.self)

--- a/Sources/Views/ALKFriendFormCell.swift
+++ b/Sources/Views/ALKFriendFormCell.swift
@@ -171,6 +171,7 @@ class ALKFriendFormCell: ALKFormCell {
             $0.bottom == timeLabel.topAnchor - ChatCellPadding.ReceivedMessage.MessageButton.bottom
             $0.leading == itemListView.leadingAnchor
         }
+        submitButtonView.trailingAnchor.constraint(lessThanOrEqualTo: messageView.trailingAnchor).isActive = true
         nameLabel.isHidden = KMCellConfiguration.hideSenderName
     }
 }

--- a/Sources/Views/ALKFriendFormCell.swift
+++ b/Sources/Views/ALKFriendFormCell.swift
@@ -170,7 +170,6 @@ class ALKFriendFormCell: ALKFormCell {
         submitButtonView.layout {
             $0.bottom == timeLabel.topAnchor - ChatCellPadding.ReceivedMessage.MessageButton.bottom
             $0.leading == itemListView.leadingAnchor
-            $0.trailing == itemListView.trailingAnchor
         }
         nameLabel.isHidden = KMCellConfiguration.hideSenderName
     }


### PR DESCRIPTION
## Summary

-  Added border to form. Colour code is similar to the android form border.
-  Removed the padding from the top of the cell but this is only available for iOS 15 and above. Tried multiple ways to remove the padding but only this method worked.
-  Removed the trailing anchor of submit button. This was stretching the button frame earlier.  

## Image
![Simulator Screenshot - SampleAppTesting - 2023-08-07 at 18 39 47](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/961c21d1-cc57-48b5-aebc-c3bb41dc3cab)

![Simulator Screenshot - SampleAppTesting - 2023-08-08 at 13 41 25](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/256b896c-26a8-4e05-b007-5cf28bc450ea)





