### PR TITLE
[CM-1538] Improved UI of multiple language selection & make it similar to android

### DIFF
--- a/Sources/Controllers/KMBottomSheetcontroller.swift
+++ b/Sources/Controllers/KMBottomSheetcontroller.swift
@@ -1,0 +1,96 @@
+//
+//  KMBottomSheetcontroller.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by sathyan elangovan on 10/08/23.
+//
+
+import UIKit
+
+class KMBottomSheetcontroller: UIPresentationController {
+
+    private var dimmingView: UIView = {
+        let dimmingView = UIView()
+        dimmingView.translatesAutoresizingMaskIntoConstraints = false
+        dimmingView.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
+        dimmingView.alpha = 0.0
+        return dimmingView
+    }()
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+
+        guard let containerView = containerView,
+            let presentedView = presentedView else { return .zero }
+
+        let containerViewframe = containerView.bounds
+        // Using autolayout to calculate the frame instead of manually
+        // setting a frame
+        let targetWidth = containerViewframe.width
+        let fittingSize = CGSize(
+            width: targetWidth,
+            height: UIView.layoutFittingCompressedSize.height
+        )
+        let targetHeight = presentedView.systemLayoutSizeFitting(
+            fittingSize, withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel).height
+
+        var frame = containerViewframe
+        frame.origin.y += frame.size.height - targetHeight
+        frame.size.width = targetWidth
+        frame.size.height = targetHeight
+        return frame
+    }
+
+    override init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
+        super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+    }
+
+    override func presentationTransitionWillBegin() {
+
+        guard let containerView = containerView else { return }
+
+        containerView.insertSubview(dimmingView, at: 0)
+        NSLayoutConstraint.activate([
+            dimmingView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            dimmingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            dimmingView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            dimmingView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        ])
+
+        guard let coordinator = presentedViewController.transitionCoordinator else {
+            dimmingView.alpha = 1
+            return
+        }
+
+        coordinator.animate(alongsideTransition: { _ in
+            self.dimmingView.alpha = 1
+        })
+    }
+
+    override func dismissalTransitionWillBegin() {
+        guard let coordinator = presentedViewController.transitionCoordinator else {
+            dimmingView.alpha = 0
+            return
+        }
+
+        coordinator.animate(alongsideTransition: { (_) in
+            self.dimmingView.alpha = 0
+        })
+    }
+
+    override func containerViewDidLayoutSubviews() {
+        super.containerViewDidLayoutSubviews()
+        presentedView?.frame = frameOfPresentedViewInContainerView
+    }
+
+    override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+        super.preferredContentSizeDidChange(forChildContentContainer: container)
+        presentedView?.frame = frameOfPresentedViewInContainerView
+    }
+}
+
+class KMBottomSheetTransitionDelegate: NSObject, UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        return KMBottomSheetcontroller(presentedViewController: presented, presenting: presenting)
+    }
+}

--- a/Sources/Views/KMLanguageView.swift
+++ b/Sources/Views/KMLanguageView.swift
@@ -1,0 +1,98 @@
+//
+//  KMLanguageView.swift
+//  KommunicateChatUI-iOS-SDKa
+//
+//  Created by sathyan elangovan on 10/08/23.
+//
+
+import Foundation
+import UIKit
+import KommunicateCore_iOS_SDK
+
+public class KMLanguageView: UIView {
+
+    public enum Style {
+        public static var dividerColor = UIColor.lightGray
+        public static var minHeight: CGFloat = 35
+        public static var padding = Padding(left: 14, right: 14, top: 4, bottom: 8)
+        public static var selectedBackgroundColor = UIColor(hexString: "686464", alpha: 1)
+        public static var selectedNameTextColor = UIColor(hexString: "ffffff", alpha: 1)
+        public static var languageNameTextColor = UIColor(hexString: "29292a", alpha: 1)
+        public static var languageNameFont = UIFont.systemFont(ofSize: 15)
+        
+        public enum LineStyle {
+            public static var height = 1.0
+            public static var top = 4.0
+            public static var bottom = 2.0
+        }
+    }
+
+    
+    let title: String
+    let maxWidth: CGFloat
+    var languageObjectList : [KMLanguage]
+    var languageTapped: ((KMLanguage) -> Void)?
+    
+    private let label = UILabel()
+    
+    private let lineView: UIView = {
+        let view = UIView(frame: .zero)
+        view.backgroundColor = UIColor.lightGray
+        return view
+    }()
+    
+
+    public init(title: String, languageList: [KMLanguage], maxWidth: CGFloat = UIScreen.main.bounds.width) {
+        self.title = title
+        self.maxWidth = maxWidth
+        self.languageObjectList = languageList
+        super.init(frame: .zero)
+        setupView()
+        setupConstraint()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+        label.text = title
+        label.textColor = Style.languageNameTextColor
+        label.font = Style.languageNameFont
+        if let savedLanguageCode = ALApplozicSettings.getSelectedLanguageForSpeechToText(),
+           let savedLanguage = languageObjectList.first(where: {$0.code == savedLanguageCode}), savedLanguage.name == title {
+            label.setBackgroundColor(Style.selectedBackgroundColor)
+            label.setTextColor(Style.selectedNameTextColor)
+        }
+    }
+
+    private func setupConstraint() {
+        addViewsForAutolayout(views: [label, lineView])
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.padding.left),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.padding.right),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: Style.padding.top),
+            label.heightAnchor.constraint(equalToConstant: Style.minHeight),
+            lineView.topAnchor.constraint(equalTo: label.bottomAnchor, constant: Style.LineStyle.top),
+            lineView.leadingAnchor.constraint(equalTo: label.leadingAnchor),
+            lineView.trailingAnchor.constraint(equalTo: label.trailingAnchor),
+            lineView.heightAnchor.constraint(equalToConstant: Style.LineStyle.height),
+            lineView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.LineStyle.bottom)
+            
+        ])
+        // Tap gesture
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(languageTap))
+        self.addGestureRecognizer(tapGesture)
+    }
+    
+    
+    @objc func languageTap() {
+        if let selectedLanguage = languageObjectList.first(where: {$0.name == title}) {
+            ALApplozicSettings.setSelectedLanguageForSpeechToText(selectedLanguage.code)
+            languageTapped?(selectedLanguage)
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- improved the UI of language selection for speech to text
- made it similar to android bottom sheet instead of presenting screen
- provided customization for curtain items


##SS
### before
<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/34a3d101-2235-44cf-983f-42b5c723cd69' width = 250 height = 400 />


### After the improvement
<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/58320729-302e-4694-b833-fd49036fb8db' width = 250 height = 400 />
