### PR TITLE
[CM-1590] Crash fix while updating agent app to the latest ios sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Crash fix for agent app while updating it to latest ios SDK
+
 ## [1.1.4] 2023-08-11
 - Improved UI of multiple language selection & make it similar to android
 - Refresh Icon Change

--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -156,7 +156,7 @@ class ALKHTTPManager: NSObject {
         let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let imageFilePath = task.filePath
         let filePath = docDirPath.appendingPathComponent(imageFilePath ?? "")
-        if ALApplozicSettings.isS3StorageServiceEnabled() && ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
+        if ALApplozicSettings.isS3StorageServiceEnabled() , let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty {
             task.fileName = Constants.AWSEncryptedPrefix + task.fileName!
         }
         guard let postURLRequest = ALRequestHandler.createPOSTRequest(withUrlString: task.url?.description, paramString: nil) as NSMutableURLRequest? else { return }
@@ -194,7 +194,7 @@ class ALKHTTPManager: NSObject {
                 }
                
                 
-                if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
+                if let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty {
                     body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
                     body.append(String(format: "Content-Disposition: form-data; name=\"%@\";\r\n",  "data").data(using: .utf8)!)
                     body.append(String(format: "Content-Type:%@\r\n\r\n", "application/json").data(using: .utf8)!)

--- a/Sources/Utilities/ALKVideoUploadManager.swift
+++ b/Sources/Utilities/ALKVideoUploadManager.swift
@@ -131,7 +131,7 @@ class ALKVideoUploadManager: NSObject {
              body.append(String(format: "\r\n").data(using: .utf8)!)
          }
 
-        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
+        if let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty {
             body.append(String(format: "--%@\r\n", boundary).data(using: .utf8)!)
             body.append(String(format: "Content-Disposition: form-data; name=\"%@\";\r\n",  "data").data(using: .utf8)!)
             body.append(String(format: "Content-Type:%@\r\n\r\n", "application/json").data(using: .utf8)!)

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -221,7 +221,7 @@ extension ALMessage {
             return .email
         }
         
-        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty && Int32(contentType) == ALMESSAGE_CONTENT_ATTACHMENT {
+        if let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty, Int32(contentType) == ALMESSAGE_CONTENT_ATTACHMENT {
             return richMessageType()
         }
         

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -915,7 +915,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
         guard let fileInfo = responseDict as? [String: Any] else { return }
 
-        if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty,let metadata = fileInfo["metadata"] as? [String:Any] {
+        if let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty,let metadata = fileInfo["metadata"] as? [String:Any] {
             message.metadata = modfiedMessageMetadata(alMessage: message, metadata: metadata)
         } else if ALApplozicSettings.isS3StorageServiceEnabled() {
             message.fileMeta.populate(fileInfo)
@@ -946,7 +946,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             guard let mesg = updatedMessage else { return }
             DispatchQueue.main.async {
                 NSLog("UI updated at section: \(indexPath.section), \(message.isSent)")
-                if !ALApplozicSettings.getDefaultOverrideuploadUrl().isEmpty {
+                if let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty {
                     // while storing message type was photo.Since Attachment is uploaded to client server, now its a rich message. thatswhy replacing it in DB.
                     messageService.deleteMessage(byKey: message.key)
                     messageService.add(updatedMessage)


### PR DESCRIPTION
## Summary

Added a null check for the `ALApplozicSettings.getDefaultOverrideuploadUrl()` inside `ALMessage+Extension.swift`