### PR TITLE
[CM-1391] Passed languageCode in groupMetadata and messageMetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Passed languageCode in groupMetadata and messageMetaData
+
 ## [1.1.5] 2023-08-23
 - Crash fix for agent app while updating it to latest ios SDK
 - Added validation and default value for form type rich message

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1677,7 +1677,26 @@ open class ALKConversationViewModel: NSObject, Localizable {
         alMessage.source = Int16(AL_SOURCE_IOS)
         alMessage.conversationId = conversationId
         alMessage.groupId = channelKey
+        setMetaDataForMessage(alMessage: alMessage)
         return alMessage
+    }
+    
+    private func setMetaDataForMessage(alMessage : ALMessage){
+        do {
+            var languageDict : [String:String] = [:]
+            let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
+            if let languageCodeString = languageCode.map(String.init) {
+                languageDict["kmUserLocale"] = languageCodeString
+            }
+            let messageInfoData = try JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted)
+            let messageInfoString = String(data: messageInfoData, encoding: .utf8) ?? ""
+            if(alMessage.metadata == nil){
+                alMessage.metadata = NSMutableDictionary()
+            }
+            alMessage.metadata["KM_CHAT_CONTEXT"] = messageInfoString
+        } catch {
+            print("error while setting message metadata : \(error.localizedDescription)")
+        }
     }
 
     private func getFileMetaInfo() -> ALFileMetaInfo {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1682,20 +1682,16 @@ open class ALKConversationViewModel: NSObject, Localizable {
     }
     
     private func setMetaDataForMessage(alMessage : ALMessage){
-        do {
-            guard var languageCode = NSLocale.preferredLanguages.first?.prefix(2) else {
-                return
-            }
-            let languageDict = ["kmUserLocale" : languageCode]
-            let messageInfoData = try JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted)
-            if alMessage.metadata == nil {
-                alMessage.metadata = NSMutableDictionary()
-            }
-            alMessage.metadata["KM_CHAT_CONTEXT"] = String(data: messageInfoData, encoding: .utf8)
-            
-        } catch {
-            print("error while setting message metadata : \(error.localizedDescription)")
+        guard let languageCode = NSLocale.preferredLanguages.first?.prefix(2) else {
+            return
         }
+        let languageDict = ["kmUserLocale" : languageCode]
+
+        guard let messageInfoData = try? JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted), alMessage.metadata == nil else {
+            return
+        }
+        alMessage.metadata = NSMutableDictionary()
+        alMessage.metadata["KM_CHAT_CONTEXT"] = String(data: messageInfoData, encoding: .utf8)
     }
 
     private func getFileMetaInfo() -> ALFileMetaInfo {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1683,17 +1683,16 @@ open class ALKConversationViewModel: NSObject, Localizable {
     
     private func setMetaDataForMessage(alMessage : ALMessage){
         do {
-            var languageDict : [String:String] = [:]
-            let languageCode = NSLocale.preferredLanguages.first?.prefix(2)
-            if let languageCodeString = languageCode.map(String.init) {
-                languageDict["kmUserLocale"] = languageCodeString
+            guard var languageCode = NSLocale.preferredLanguages.first?.prefix(2) else {
+                return
             }
+            let languageDict = ["kmUserLocale" : languageCode]
             let messageInfoData = try JSONSerialization.data(withJSONObject: languageDict, options: .prettyPrinted)
-            let messageInfoString = String(data: messageInfoData, encoding: .utf8) ?? ""
-            if(alMessage.metadata == nil){
+            if alMessage.metadata == nil {
                 alMessage.metadata = NSMutableDictionary()
             }
-            alMessage.metadata["KM_CHAT_CONTEXT"] = messageInfoString
+            alMessage.metadata["KM_CHAT_CONTEXT"] = String(data: messageInfoData, encoding: .utf8)
+            
         } catch {
             print("error while setting message metadata : \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
Passed `kmUserLocale` inside groupMetadata and messageMetadata which is used to display welcome message in a specific language

## Testing

1. Send a message and check for the received MQTT message. Here inside the message object's metadata field verify that whether your device's primary language is showing or not.

```
 {
  "id": "36bad4a021de46aaf2be7819b0bd45472",
  "type": "APPLOZIC_02",
  "message": {
    "key": "5-91921780-1692969360367",
    "oldKey": "cadea924-fafa-49c2-866d-8bccc7d523d2",
    "deviceKey": "d20aec1e-9ddb-4884-9b4c-7162c468fb18",
    "userKey": "9c6c7209-081e-4301-a9a9-bb298f7f37dc",
    "to": "e0VI2OPOzet2qEIbCb3Nezl3CW3KGoBy",
    "contactIds": "e0VI2OPOzet2qEIbCb3Nezl3CW3KGoBy",
    "message": "Tttt",
    "sent": true,
    "delivered": false,
    "read": false,
    "deliveredValue": 0,
    "sendToDevice": false,
    "shared": false,
    "createdAtTime": 1692969362747,
    "createdAt": "Aug 25, 2023 1:16:02 PM",
    "type": 5,
    "source": 2,
    "status": 3,
    "pairedMessageKey": "5-91921780-1692969360367",
    "applicationKey": "0f20aaae-916a-46b9-85a4-441461cf7614",
    "groupId": 91921780,
    "clientGroupId": "himanshu.joshi@kommunicate.io_e0VI2OPOzet2qEIbCb3Nezl3CW3KGoBy",
    "contentType": 0,
    "senderName": "e0VI2OPOzet2qEIbCb3Nezl3CW3KGoBy",
    "skipUpdationForAdmin": false,
    "metadata": {
      "KM_CHAT_CONTEXT": "{\n  \"kmUserLocale\": \"de\"\n}"
    } ,
    "alert": true,
    "unicodePresent": false,
    "sendNotificationToQueue": false
  },
  "notifyUser": true,
  "totalUnreadCount": 0,
  "sendAlert": false,
  "messageMetaData": {}
}
```