### PR TITLE
fixed image upload prod issue

### DIFF
--- a/Sources/Utilities/ALKHTTPManager.swift
+++ b/Sources/Utilities/ALKHTTPManager.swift
@@ -156,7 +156,7 @@ class ALKHTTPManager: NSObject {
         let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let imageFilePath = task.filePath
         let filePath = docDirPath.appendingPathComponent(imageFilePath ?? "")
-        if ALApplozicSettings.isS3StorageServiceEnabled() , let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), !uploadUrl.isEmpty {
+        if ALApplozicSettings.isS3StorageServiceEnabled() , let uploadUrl = ALApplozicSettings.getDefaultOverrideuploadUrl(), uploadUrl.isEmpty {
             task.fileName = Constants.AWSEncryptedPrefix + task.fileName!
         }
         guard let postURLRequest = ALRequestHandler.createPOSTRequest(withUrlString: task.url?.description, paramString: nil) as NSMutableURLRequest? else { return }


### PR DESCRIPTION
## Summary
- image Uploaded from iOS not getting downloaded on Android Agent App & Dashboard
- It was created from the last release. Fixed the wrong check code