### PR TITLE
Fixed video not sending

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2601,7 +2601,7 @@ extension ALKConversationViewController: ALKCustomPickerDelegate {
             } else {
                 let path = videos[index - images.count]
                 
-                if let size = FileManager().sizeOfFile(atPath: path), size > ALApplozicSettings.getMaxImageSizeForUploadInMB() {
+                if let size = FileManager().sizeOfFile(atPath: path), size > (ALApplozicSettings.getMaxImageSizeForUploadInMB() * 1024) {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: {
                         self.showUploadRestrictionAlert()
                     })


### PR DESCRIPTION
## Summary

File size in KB was being tested with maximumAttachmentSize which was in MB so converted maximumAttachmentSize to KB as well