### PR TITLE
[CM-1567] Fixed After deleting the last conversation on conversation list screen & empty state should be shown 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed the delete conversation showing the empty screen.  
+
 ## [1.1.7] 2023-09-07
 - Added support for Sending GIF from device
 - Added icons for (mobile/web/facebook/WhatsApp) on conversation list for agent app. 

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -177,7 +177,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
                 channelDbService.deleteChannel(conversation.groupId)
                 self.viewModel.remove(message: conversation)
                 self.tableView.reloadData()
-                DispatchQueue.main.asyncAfter(deadline: .now()) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     self.showAlertWithSingleAction(message: self.localizedString(
                         forKey: "DeleteConversationSuccessMessage",
                         withDefaultValue: SystemMessage.DeleteConversationPopup.success,

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -177,7 +177,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
                 channelDbService.deleteChannel(conversation.groupId)
                 self.viewModel.remove(message: conversation)
                 self.tableView.reloadData()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                DispatchQueue.main.asyncAfter(deadline: .now()) {
                     self.showAlertWithSingleAction(message: self.localizedString(
                         forKey: "DeleteConversationSuccessMessage",
                         withDefaultValue: SystemMessage.DeleteConversationPopup.success,

--- a/Sources/ViewModels/ALKConversationListViewModel.swift
+++ b/Sources/ViewModels/ALKConversationListViewModel.swift
@@ -133,6 +133,7 @@ public final class ALKConversationListViewModel: NSObject, ALKConversationListVi
             return
         }
         allMessages.remove(at: index)
+        updateMessageList(messages: allMessages)
     }
 
     public func updateTypingStatus(in viewController: ALKConversationViewController, userId: String, status: Bool) {

--- a/Sources/ViewModels/ALKConversationListViewModel.swift
+++ b/Sources/ViewModels/ALKConversationListViewModel.swift
@@ -133,7 +133,9 @@ public final class ALKConversationListViewModel: NSObject, ALKConversationListVi
             return
         }
         allMessages.remove(at: index)
-        updateMessageList(messages: allMessages)
+        if allMessages.count == 0 {
+            updateMessageList(messages: allMessages)
+        }
     }
 
     public func updateTypingStatus(in viewController: ALKConversationViewController, userId: String, status: Bool) {


### PR DESCRIPTION
## Summary
- Called update message list after every delete of the message.
- Removed the delay of showing the delete conversation alert.

https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/55034aa9-ca51-4474-b982-a1689291b102

