### PR TITLE
[CM-1616] Fixed Trial Period Alert closable issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed Trial Period Alert closable issue.
+
 ## [1.1.7] 2023-09-07
 - Added support for Sending GIF from device
 - Added icons for (mobile/web/facebook/WhatsApp) on conversation list for agent app. 

--- a/Sources/Controllers/ALKAccountSuspensionController.swift
+++ b/Sources/Controllers/ALKAccountSuspensionController.swift
@@ -51,6 +51,7 @@ public class ALKAccountSuspensionController: UIViewController {
         let closeImage = UIImage(named: "close", in: Bundle.km, compatibleWith: nil)
         button.setImage(closeImage, for: .normal)
         button.tintColor = UIColor.black
+        button.isHidden = true
         return button
     }
 }

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -343,6 +343,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
 
     override open func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
+        accountVC.isModalInPresentation = true
         accountVC.closePressed = { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -489,6 +489,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     override open func showAccountSuspensionView() {
         let accountVC = ALKAccountSuspensionController()
+        accountVC.isModalInPresentation = true
         accountVC.closePressed = { [weak self] in
             self?.dismiss(animated: true, completion: nil)
         }


### PR DESCRIPTION
## Summary
- used the function isModalInPresentation to remove the swipe to close functionality. (by default it is false)
- hide the close button.


https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/8b829b29-f6ef-4410-b25b-2f0cdc4c24fd

