### PR TITLE
[CM-1647] Disabled kommunicate.io showing in iOS 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 - Fixed Trial Period Alert closable issue.
 - Fixed the delete conversation showing the empty screen.  
 - Added support for XCode 15
+- Fixed kommunicate.io showing in iOS 17 even when it is disabled
 
 
 ## [1.1.7] 2023-09-07

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -50,6 +50,7 @@ open class ALKChatBar: UIView, Localizable {
         textView.isUserInteractionEnabled = true
         textView.isSelectable = true
         textView.isEditable = false
+        textView.isHidden = true
         textView.textContainer.maximumNumberOfLines = 1
         textView.textContainer.lineBreakMode = .byTruncatingTail
         textView.backgroundColor = UIColor.darkGray
@@ -612,6 +613,7 @@ open class ALKChatBar: UIView, Localizable {
     }
 
     public func showPoweredByMessage() {
+        poweredByMessageTextView.isHidden = false
         poweredByMessageTextView.constraint(withIdentifier: ConstraintIdentifier.poweredByMessageHeight.rawValue)?.constant = 20
     }
 


### PR DESCRIPTION
## Summary
Fixed "kommunicate.io" showing in iOS 17 even when "powered by kommunicate.io" should be disabled