### PR TITLE
[CM- 1315] Button Lengthy title support not working on iPhone 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed the Button Title hidding in smaller devices.
+
 ## [1.1.8] 2023-09-26
 - Added Support For Auto Suggestions Rich Message
 - Added custom input field rich message support in IOS SDK

--- a/RichMessageKit/Views/core/SuggestedReplyView.swift
+++ b/RichMessageKit/Views/core/SuggestedReplyView.swift
@@ -176,6 +176,7 @@ public class SuggestedReplyView: UIView {
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.alignment = .center
         stackView.axis = .horizontal
+        stackView.distribution = .fill
         return stackView
     }
     

--- a/RichMessageKit/Views/core/SuggestedReplyView.swift
+++ b/RichMessageKit/Views/core/SuggestedReplyView.swift
@@ -144,7 +144,12 @@ public class SuggestedReplyView: UIView {
                 let hiddenView = hiddenViewUsing(currWidth: width - button.buttonWidth(), maxWidth: maxWidth, subViews: subviews)
                 alignLeft ? subviews.append(hiddenView) : subviews.insert(hiddenView, at: 0)
                 width = button.buttonWidth() + 10
-                let stackView = horizontalStackView(subviews: subviews)
+                let stackView: UIStackView
+                if subviews.count > 2 {
+                    stackView = horizontalStackViewWithSpace(subviews: subviews)
+                } else {
+                    stackView = horizontalStackView(subviews: subviews)
+                }
                 mainStackView.addArrangedSubview(stackView)
                 subviews.removeAll()
                 subviews.append(button)
@@ -157,12 +162,24 @@ public class SuggestedReplyView: UIView {
         if isMultiLine {
             alignLeft ? subviews.append(hiddenView) : subviews.insert(hiddenView, at: 0)
         }
-
-        let stackView = horizontalStackView(subviews: subviews)
+        let stackView: UIStackView
+        if subviews.count > 2 {
+            stackView = horizontalStackViewWithSpace(subviews: subviews)
+        } else {
+            stackView = horizontalStackView(subviews: subviews)
+        }
+        
         mainStackView.addArrangedSubview(stackView)
     }
 
     private func horizontalStackView(subviews: [UIView]) -> UIStackView {
+        let stackView = UIStackView(arrangedSubviews: subviews)
+        stackView.alignment = .center
+        stackView.axis = .horizontal
+        return stackView
+    }
+    
+    private func horizontalStackViewWithSpace(subviews: [UIView]) -> UIStackView {
         let stackView = UIStackView(arrangedSubviews: subviews)
         stackView.spacing = 10
         stackView.alignment = .center


### PR DESCRIPTION
## Summary
- Spacing in UIStackView are creating this issue when less than three subviews are passing.
- Created a new UIStackView conversion function with no spacing.
- added a check for subviews to pass evenly to horizontalStackView and horizontalStackViewWithSpace.

## Images
**Before Changes (iPhone 7 / IPhone 15 Pro Max)**
<img src ='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/d6e8041e-e972-4f3d-95cd-7ecdbfca4523' width = 200 height = 400 /> <img src ='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/c029703f-f3aa-425b-9222-29360c475888' width = 200 height = 400 />
**After Changes (iPhone 7 / IPhone 15 Pro Max)**
<img src ='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/2bb08953-ea29-4301-a3f5-9a670ccc2102' width = 200 height = 400 /> <img src ='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/b5c48ae6-f2a6-4c7c-9255-cb125635d90a' width = 200 height = 400 />



