### PR TITLE
[CM-1652] Fixed conversation history mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+##Unreleased
+- Fixed conversation history mismatch
+
 ## [1.1.8] 2023-09-26
 - Added Support For Auto Suggestions Rich Message
 - Added custom input field rich message support in IOS SDK
@@ -9,7 +12,6 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 - Fixed the delete conversation showing the empty screen.  
 - Added support for XCode 15
 - Fixed kommunicate.io showing in iOS 17 even when it is disabled
-
 
 ## [1.1.7] 2023-09-07
 - Added support for Sending GIF from device

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -474,6 +474,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             loadOpenGroupMessages()
             return
         }
+        self.delegate?.loadingStarted()
         loadMessagesFromDB()
     }
 


### PR DESCRIPTION
## Summary
- Users were not able to fetch only first few messages which is fixed now

### Last conversation from ios ->
![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-06 at 17 31 22](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/ba367747-ed16-4cfb-91c9-8286de4d3e46)
### Last conversation from android ->
![Screenshot_20231006-173840](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/a79a1f86-f1cd-4b08-8c06-0fe45e5dd45c)