### PR TITLE
[CM-1636] Changed foreground color for links 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+##Unreleased
+- Fixed conversation history mismatch
+- Changed foreground color for link present inside message
+
 ## [1.1.8] 2023-09-26
 - Added Support For Auto Suggestions Rich Message
 - Added custom input field rich message support in IOS SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
 ## Unreleased
-- Fixed conversation history mismatch
 - Changed foreground color for link present inside message
 
 ## [1.1.8] 2023-09-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
-##Unreleased
+## Unreleased
 - Fixed conversation history mismatch
 - Changed foreground color for link present inside message
 

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -37,6 +37,10 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         cell.replyViewAction = { [weak self] in
             self?.scrollTo(message: message)
         }
+        if(message.isMyMessage){
+            cell.messageView.linkTextAttributes = [.foregroundColor: configuration.linkAttributeColorForSentMessage,
+                                           .underlineStyle: NSUnderlineStyle.single.rawValue]
+        }
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -37,10 +37,8 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         cell.replyViewAction = { [weak self] in
             self?.scrollTo(message: message)
         }
-        if(message.isMyMessage){
-            cell.messageView.linkTextAttributes = [.foregroundColor: configuration.linkAttributeColorForSentMessage,
-                                           .underlineStyle: NSUnderlineStyle.single.rawValue]
-        }
+        cell.messageView.linkTextAttributes = [.foregroundColor: (message.isMyMessage) ? configuration.linkAttributeColorForSentMessage : configuration.linkAttributeColorForReceivedMessage,
+                                               .underlineStyle: NSUnderlineStyle.single.rawValue]
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -206,6 +206,8 @@ public struct ALKConfiguration {
     
     /// If true then on tap of list template(link) browser will not be opened. By default it is false
     public var restrictLinkNavigationOnListTemplateTap = false
+    
+    public var linkAttributeColorForSentMessage = UIColor.white
 
 
     /// If true, contact share option in chatbar will be hidden.

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -207,6 +207,7 @@ public struct ALKConfiguration {
     /// If true then on tap of list template(link) browser will not be opened. By default it is false
     public var restrictLinkNavigationOnListTemplateTap = false
     
+    /// Changing this will change the color of link text present inside the sent message
     public var linkAttributeColorForSentMessage = UIColor.white
 
 

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -209,6 +209,9 @@ public struct ALKConfiguration {
     
     /// Changing this will change the color of link text present inside the sent message
     public var linkAttributeColorForSentMessage = UIColor.white
+    
+    /// Changing this will change the color of link text present inside the received message
+    public var linkAttributeColorForReceivedMessage = UIColor.blue
 
 
     /// If true, contact share option in chatbar will be hidden.

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -88,7 +88,7 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
         textView.isSelectable = true
         textView.isEditable = false
         textView.dataDetectorTypes = .link
-        textView.linkTextAttributes = [.foregroundColor: UIColor.white,
+        textView.linkTextAttributes = [.foregroundColor: UIColor.blue,
                                        .underlineStyle: NSUnderlineStyle.single.rawValue]
         textView.isScrollEnabled = false
         textView.delaysContentTouches = false

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -88,7 +88,7 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
         textView.isSelectable = true
         textView.isEditable = false
         textView.dataDetectorTypes = .link
-        textView.linkTextAttributes = [.foregroundColor: UIColor.blue,
+        textView.linkTextAttributes = [.foregroundColor: UIColor.white,
                                        .underlineStyle: NSUnderlineStyle.single.rawValue]
         textView.isScrollEnabled = false
         textView.delaysContentTouches = false


### PR DESCRIPTION
## Summary
Earlier links were showing in blue color and as by default we have violet color as sent message background color so the link was not visible to the end user. Hence we changed it to white to make it look readable.

### Old color
![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-09 at 15 52 24](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/91d70571-b8c5-49ff-99b3-4d7969bab5e5)
### New color
![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-09 at 15 46 53](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/b095a4dd-923a-408f-96ca-661254accd8c)