### PR TITLE
[CM-1665] Submit RM Button Tap issue

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1679,6 +1679,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             let urlString = metadata["formAction"] as? String,
             let url = URL(string: urlString)
         else {
+            viewModel.send(message: text, metadata: nil)
             return
         }
         var request: URLRequest!


### PR DESCRIPTION
## Summary
- Fixed Submit Rich Message Button tap issue when form action details is not there in payload.
