### PR TITLE
[CM-1641] Fixed hidePostCTA creating extra space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+##Unrelesed
+- Fixed hidePostCTA creating extra space.
+
 ## [1.1.9] 2023-10-18
 - Fixed the Button Title hidding in smaller devices.
 - Changed foreground color for link present inside message.

--- a/RichMessageKit/Views/core/SuggestedReplyView.swift
+++ b/RichMessageKit/Views/core/SuggestedReplyView.swift
@@ -207,6 +207,20 @@ public class SuggestedReplyView: UIView {
         button.index = index
         return button
     }
+    
+    func hideActionButtons() {
+        SuggestedReplyView.didTapSuggestedReply = true
+        if let identifier = model?.message.identifier {
+            SuggestedReplyView.messageIdentifier = identifier
+        }
+        model?.suggestion.removeAll()
+        mainStackView.isHidden = true
+        guard let suggestedReplyMessage = model else {
+            return
+        }
+        setupSuggestedReplyButtons(suggestedReplyMessage, maxWidth: 0)
+    }
+    
 }
 
 extension SuggestedReplyView: Tappable {
@@ -216,10 +230,7 @@ extension SuggestedReplyView: Tappable {
         delegate?.didTap(index: index, title: replyToBeSend)
 
         if UserDefaults.standard.bool(forKey: "HidePostCTAEnabled") {
-            SuggestedReplyView.didTapSuggestedReply = true
-            SuggestedReplyView.messageIdentifier = (model?.message.identifier)!
-            model?.suggestion.removeAll()
-            mainStackView.isHidden = true
+            hideActionButtons()
         }
     }
 }

--- a/RichMessageKit/Views/core/SuggestedReplyView.swift
+++ b/RichMessageKit/Views/core/SuggestedReplyView.swift
@@ -16,6 +16,7 @@ import UIKit
 public class SuggestedReplyView: UIView {
     static var didTapSuggestedReply = false
     static var messageIdentifier = String()
+    static let hidePostCTA = "HidePostCTAEnabled"
 
     // MARK: Public properties
 

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -345,6 +345,9 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 guard let template = message.payloadFromMetadata() else {
                     return cell
                 }
+                if viewModel.isActionButtonHidden(message: message){
+                    cell.quickReplyView.hideActionButtons()
+                }
                 cell.quickReplySelected = { [weak self] index, title in
                     guard let weakSelf = self else { return }
                     weakSelf.quickReplySelected(

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2193,9 +2193,11 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         var messageIndex = index-1;
         while messageIndex >= 0 && messageIndex < viewModel.messageModels.count && !viewModel.messageModels[messageIndex].isMyMessage {
             let message = viewModel.messageModels[messageIndex]
-            if(message.messageType == .allButtons || message.messageType == .quickReply){
+            if message.messageType == .allButtons {
                 viewModel.messageModels.remove(at: messageIndex)
                 tableView.deleteSections([messageIndex], with: .automatic)
+            } else if message.messageType == .quickReply {
+                tableView.reloadSections([messageIndex], with: .automatic)
             }
             messageIndex-=1
         }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2162,6 +2162,10 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
                 return
             }
             self.tableView.reloadSections(IndexSet(integer: indexPath.section), with: .none)
+            let message = self.viewModel.messageModels[indexPath.section]
+            if(UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) && message.isMyMessage){
+                self.deleteProcessedMessages(index: indexPath.section)
+            }
         }
     }
 
@@ -2180,6 +2184,22 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
                 self.tableView.scrollToRow(at: indexPath, at: .bottom, animated: false)
             }
         }
+    }
+    
+    func deleteProcessedMessages(index : Int){
+        guard index >= 0 && viewModel.messageModels[index].isMyMessage else {
+            return
+        }
+        var messageIndex = index-1;
+        while messageIndex >= 0 && messageIndex < viewModel.messageModels.count && !viewModel.messageModels[messageIndex].isMyMessage {
+            let message = viewModel.messageModels[messageIndex]
+            if(message.messageType == .allButtons || message.messageType == .quickReply){
+                viewModel.messageModels.remove(at: messageIndex)
+                tableView.deleteSections([messageIndex], with: .automatic)
+            }
+            messageIndex-=1
+        }
+        moveTableViewToBottom(indexPath: IndexPath(row: 0, section: tableView.numberOfSections - 1))
     }
     
     public func updateChatbarText(text: String) {

--- a/Sources/Models/ALKMessageModel.swift
+++ b/Sources/Models/ALKMessageModel.swift
@@ -68,6 +68,7 @@ public protocol ALKMessageViewModel {
     var metadata: [String: Any]? { get }
     var source: Int16 { get }
     var contentType: Message.ContentType { get }
+    var createdAtTime : NSNumber? { get set }
 }
 
 public class ALKMessageModel: ALKMessageViewModel {
@@ -101,6 +102,7 @@ public class ALKMessageModel: ALKMessageViewModel {
     public var isReplyMessage: Bool = false
     public var metadata: [String: Any]?
     public var source: Int16 = 0
+    public var createdAtTime: NSNumber?
 }
 
 extension ALKMessageModel: Equatable {

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -469,6 +469,7 @@ public extension ALMessage {
         messageModel.isReplyMessage = isAReplyMessage()
         messageModel.metadata = metadata as? [String: Any]
         messageModel.source = source
+        messageModel.createdAtTime = createdAtTime
         if let messageContentType = Message.ContentType(rawValue: contentType) {
             messageModel.contentType = messageContentType
         }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -49,6 +49,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
     open var isSearch: Bool = false
     open var lastMessage : ALMessage?
+    open var lastSentMessage : ALMessage?
 
     // For topic based chat
     open var conversationProxy: ALConversationProxy? {
@@ -182,6 +183,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
         guard !alMessageWrapper.contains(message: message) else { return }
         alMessageWrapper.addALMessage(toMessageArray: message)
         alMessages.append(message)
+        if(message.isMyMessage){
+            lastSentMessage = message
+        }
         messageModels.append(message.messageModel)
     }
 
@@ -392,6 +396,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
                         .cached(with: cacheIdentifier)
             } else {
+                if isActionButtonHidden(message: messageModel) {
+                    return 0
+                }
                 return
                     ALKFriendMessageQuickReplyCell
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
@@ -452,7 +459,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
                     SentButtonsCell
                         .rowHeight(model: model)
                         .cached(with: cacheIdentifier)
-            } else {
+            }
+            else {
+                if isActionButtonHidden(message: messageModel) {
+                    return 0
+                }
                 return
                     ReceivedButtonsCell
                         .rowHeight(model: model)
@@ -1389,6 +1400,10 @@ open class ALKConversationViewModel: NSObject, Localizable {
             if !KMConversationScreenConfiguration.staticTopMessage.isEmpty {
                 self.alMessages.insert(self.getInitialStaticFirstMessage(), at: 0)
             }
+            
+            if(self.lastSentMessage == nil){
+                self.lastSentMessage = self.getLastSentMessage()
+            }
 
             self.alMessageWrapper.addObject(toMessageArray: messages)
             
@@ -1397,8 +1412,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             if self.isConversationAssignedToBot() && (self.botDelayTime > 0) && !self.isOldConversation() {
                 self.showTypingIndicatorForWelcomeMessage()
             } else {
-                self.messageModels = self.modelsToBeAddedAfterDelay
-               
+                self.addMessageToMessageModel(messages: self.modelsToBeAddedAfterDelay)
             }
             self.membersInGroup { members in
                 self.groupMembers = members
@@ -1406,6 +1420,15 @@ open class ALKConversationViewModel: NSObject, Localizable {
             }
         })
         self.lastMessage = alMessages.last
+    }
+    
+    func getLastSentMessage() -> ALMessage? {
+        for message in alMessages.reversed() {
+            if(message.isMyMessage){
+                return message
+            }
+        }
+        return nil
     }
     
     /*
@@ -1593,8 +1616,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
             self.alMessages.insert(contentsOf: messages as! [ALMessage], at: 0)
 
             self.alMessageWrapper.addObject(toMessageArray: messages)
+            if(self.lastSentMessage == nil){
+                self.lastSentMessage = self.getLastSentMessage()
+            }
             let models = messages.map { ($0 as! ALMessage).messageModel }
-            self.messageModels.insert(contentsOf: models, at: 0)
+            self.addMessageToMessageModel(messages: models)
             if isFirstTime {
                 self.membersInGroup { members in
                     self.groupMembers = members
@@ -1605,6 +1631,25 @@ open class ALKConversationViewModel: NSObject, Localizable {
             }
         })
         self.lastMessage = alMessages.last
+    }
+    
+    func addMessageToMessageModel(messages : [ALKMessageModel]){
+        
+        guard let lastSentMessageTime = lastSentMessage?.createdAtTime,
+              UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) else {
+            self.messageModels.insert(contentsOf: messages, at: 0)
+            return
+        }
+        
+        for message in messages {
+            if let currentMessageTime = message.createdAtTime {
+                if message.isMyMessage ||
+                    (message.messageType != .allButtons && message.messageType != .quickReply) ||
+                    currentMessageTime .int64Value >= lastSentMessageTime .int64Value {
+                    self.messageModels.append(message)
+                }
+            }
+        }
     }
 
     open func loadOpenGroupMessages() {
@@ -1722,7 +1767,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 }
                 self.alMessageWrapper.getUpdatedMessageArray().insert(newMessages, at: 0)
                 self.alMessages.insert(mesg, at: 0)
-                self.messageModels.insert(mesg.messageModel, at: 0)
+                self.addMessageToMessageModel(messages: [mesg.messageModel])
             }
             self.delegate?.loadingFinished(error: nil)
         })
@@ -1975,6 +2020,17 @@ open class ALKConversationViewModel: NSObject, Localizable {
             }
             completion(contacts)
         }
+    }
+    
+    func isActionButtonHidden(message : ALKMessageViewModel) -> Bool {
+        guard UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA),
+              let currentMessageTime = message.createdAtTime,
+              let lastSentMessageTime = lastSentMessage?.createdAtTime,
+              currentMessageTime .int64Value < lastSentMessageTime .int64Value else {
+            return false
+        }
+        
+        return true
     }
 }
 

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -396,12 +396,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
                         .cached(with: cacheIdentifier)
             } else {
-                if isActionButtonHidden(message: messageModel) {
-                    return 0
-                }
                 return
                     ALKFriendMessageQuickReplyCell
-                        .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
+                        .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width, isActionButtonHidden: isActionButtonHidden(message: messageModel))
             }
         case .button:
             if messageModel.isMyMessage {
@@ -1644,7 +1641,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         for message in messages {
             if let currentMessageTime = message.createdAtTime {
                 if message.isMyMessage ||
-                    (message.messageType != .allButtons && message.messageType != .quickReply) ||
+                    (message.messageType != .allButtons) ||
                     currentMessageTime .int64Value >= lastSentMessageTime .int64Value {
                     self.messageModels.append(message)
                 }

--- a/Sources/Views/ALKFriendMessageQuickReplyCell.swift
+++ b/Sources/Views/ALKFriendMessageQuickReplyCell.swift
@@ -131,7 +131,7 @@ public class ALKFriendMessageQuickReplyCell: ALKChatBaseCell<ALKMessageViewModel
         quickReplyView.update(model: suggestedReplies, maxWidth: quickReplyViewWidth)
     }
 
-    public class func rowHeight(viewModel: ALKMessageViewModel, maxWidth: CGFloat) -> CGFloat {
+    public class func rowHeight(viewModel: ALKMessageViewModel, maxWidth: CGFloat, isActionButtonHidden: Bool = false) -> CGFloat {
         let isMessageEmpty = viewModel.isMessageEmpty
         var height: CGFloat = 0
 
@@ -155,8 +155,12 @@ public class ALKFriendMessageQuickReplyCell: ALKChatBaseCell<ALKMessageViewModel
 
         let quickReplyViewWidth = maxWidth -
             (ChatCellPadding.ReceivedMessage.QuickReply.left + ChatCellPadding.ReceivedMessage.Message.right + ViewPadding.AvatarImageView.leading + ViewPadding.AvatarImageView.width + ChatCellPadding.ReceivedMessage.Message.left)
+        
+        if !isActionButtonHidden {
+            height += SuggestedReplyView.rowHeight(model: suggestedReplies, maxWidth: quickReplyViewWidth)
+        }
+        
         return height
-            + SuggestedReplyView.rowHeight(model: suggestedReplies, maxWidth: quickReplyViewWidth)
             + ChatCellPadding.ReceivedMessage.QuickReply.top
             + ChatCellPadding.ReceivedMessage.QuickReply.bottom + timeLabelSize.height.rounded(.up)
             + ViewPadding.TimeLabel.bottom


### PR DESCRIPTION
## Summary

Previously when the hidePostCTA was enabled and the user clicked on any suggested reply, the buttons were hiding but a space for that buttons was left behind which is fixed here. 

### Before

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/8fb39366-4e63-457a-804b-d3abb295f6cb" alt="before" width="300" height="525">

### After

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/cf49a709-0b6b-4b41-b305-37ae6ca6c941" alt="after" width="300" height="525">
