### PR TITLE
[CM-1459] Dark Mode Support Part -2 

### DIFF
--- a/RichMessageKit/Themes/ImageBubbleStyle.swift
+++ b/RichMessageKit/Themes/ImageBubbleStyle.swift
@@ -12,7 +12,7 @@ public struct ImageBubbleStyle {
     /// Style for caption text
     public var captionStyle = Style(
         font: UIFont.systemFont(ofSize: 12),
-        text: UIColor.dynamicColor(light: .darkText, dark: .lightText)
+        text: UIColor.kmDynamicColor(light: .darkText, dark: .lightText)
     )
 
     /// Style for image bubble

--- a/RichMessageKit/Themes/MessageStyle.swift
+++ b/RichMessageKit/Themes/MessageStyle.swift
@@ -12,19 +12,19 @@ public struct MessageStyle {
     /// Style for display name
     public var displayName = Style(
         font: UIFont.systemFont(ofSize: 14),
-        text: UIColor.dynamicColor(light: .darkText, dark: .lightText)
+        text: UIColor.kmDynamicColor(light: .darkText, dark: .lightText)
     )
 
     /// Style for message text.
     public var message = Style(
         font: UIFont.systemFont(ofSize: 14),
-        text: UIColor.dynamicColor(light: .black, dark: .white)
+        text: UIColor.kmDynamicColor(light: .black, dark: .white)
     )
 
     /// Style for time.
     public var time = Style(
         font: UIFont.systemFont(ofSize: 12),
-        text: UIColor.dynamicColor(light: .darkText, dark: .lightText)
+        text: UIColor.kmDynamicColor(light: .darkText, dark: .lightText)
     )
 
     /// Style for message bubble

--- a/RichMessageKit/Utilities/UIColor+ExtensionDarkMode.swift
+++ b/RichMessageKit/Utilities/UIColor+ExtensionDarkMode.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 public extension UIColor {
-    static func dynamicColor(light: UIColor, dark: UIColor) -> UIColor {
+    static func kmDynamicColor(light: UIColor, dark: UIColor) -> UIColor {
         return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
     }
 }

--- a/RichMessageKit/Views/core/CurvedImageButton.swift
+++ b/RichMessageKit/Views/core/CurvedImageButton.swift
@@ -160,7 +160,7 @@ public class CurvedImageButton: UIView {
         clipsToBounds = true
 
         label.text = title
-        label.textColor = UIColor.dynamicColor(light: style.buttonColor.text, dark: UIColor.white)
+        label.textColor = UIColor.kmDynamicColor(light: style.buttonColor.text, dark: UIColor.white)
         label.font = style.font
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping

--- a/Sources/Controllers/ALKBaseNavigationController.swift
+++ b/Sources/Controllers/ALKBaseNavigationController.swift
@@ -28,7 +28,7 @@ public class ALKBaseNavigationViewController: UINavigationController {
         navigationBarProxy.shadowImage = navigationBarProxy.shadowImage ?? UIImage()
         navigationBarProxy.tintColor = navigationBarProxy.tintColor ?? UIColor.navigationTextOceanBlue()
         navigationBarProxy.titleTextAttributes =
-        navigationBarProxy.titleTextAttributes ?? [NSAttributedString.Key.foregroundColor: UIColor.dynamicColor(light: .black, dark: .white)]
+        navigationBarProxy.titleTextAttributes ?? [NSAttributedString.Key.foregroundColor: UIColor.kmDynamicColor(light: .black, dark: .white)]
 
         if navigationBarProxy.backgroundImage(for: .default) == nil {
             navigationBarProxy.barTintColor = appSettingsUserDefaults.getAppBarTintColor()
@@ -37,9 +37,9 @@ public class ALKBaseNavigationViewController: UINavigationController {
             let navBarAppearance = UINavigationBarAppearance()
             navBarAppearance.configureWithOpaqueBackground()
             navBarAppearance.titleTextAttributes =
-            navigationBarProxy.titleTextAttributes ?? [NSAttributedString.Key.foregroundColor: UIColor.dynamicColor(light: .black, dark: .white)]
+            navigationBarProxy.titleTextAttributes ?? [NSAttributedString.Key.foregroundColor: UIColor.kmDynamicColor(light: .black, dark: .white)]
             if navigationBarProxy.backgroundImage(for: .default) == nil {
-                navBarAppearance.backgroundColor = UIColor.dynamicColor(light: appSettingsUserDefaults.getAppBarTintColor(), dark: UIColor.appBarDarkColor())
+                navBarAppearance.backgroundColor = UIColor.kmDynamicColor(light: appSettingsUserDefaults.getAppBarTintColor(), dark: UIColor.appBarDarkColor())
             } else {
                 navBarAppearance.backgroundImage = navigationBarProxy.backgroundImage(for: .default)
             }

--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -293,7 +293,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
         let noConversationLabelText = localizedString(forKey: "NoConversationsLabelText", withDefaultValue: SystemMessage.ChatList.NoConversationsLabelText, fileName: localizedStringFileName)
         emptyCellView.conversationLabel.text = noConversationLabelText
         emptyCellView.startNewConversationButtonIcon.isHidden = configuration.hideEmptyStateStartNewButtonInConversationList
-        emptyCellView.conversationLabel.textColor = .dynamicColor(light: .black, dark: .white)
+        emptyCellView.conversationLabel.textColor = .kmDynamicColor(light: .black, dark: .white)
 
         if !configuration.hideEmptyStateStartNewButtonInConversationList {
             if let tap = emptyCellView.gestureRecognizers?.first {
@@ -341,7 +341,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
         tableView.estimatedRowHeight = 75
         tableView.rowHeight = 75
         tableView.separatorStyle = .none
-        tableView.backgroundColor = UIColor.dynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
+        tableView.backgroundColor = UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
         tableView.keyboardDismissMode = .onDrag
         tableView.accessibilityIdentifier = "OuterChatScreenTableView"
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -803,7 +803,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         // Update background view's color which contains all the attachment options.
         chatBar.bottomBackgroundColor = UIColor.kmDynamicColor(light: configuration.chatBarAttachmentViewBackgroundColor, dark: configuration.chatBarAttachmentViewDarkBackgroundColor)
 
-        chatBar.textView.textColor = UIColor.kmDynamicColor(light: .white, dark: .black)
+        chatBar.textView.textColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         chatBar.poweredByMessageTextView.hyperLink(mutableAttributedString: NSMutableAttributedString(string: "Powered by Kommunicate.io"),
                                                    url: URL(string: "https://kommunicate.io")!,
                                                    clickString: "Kommunicate.io")

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -52,7 +52,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     public let autocompletionView: UITableView = {
         let tableview = UITableView(frame: CGRect.zero, style: .plain)
-        tableview.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        tableview.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         tableview.estimatedRowHeight = 50
         tableview.rowHeight = UITableView.automaticDimension
         tableview.separatorStyle = .none
@@ -62,7 +62,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     
     public let autoSuggestionView: UITableView = {
         let tableview = UITableView(frame: CGRect.zero, style: .plain)
-        tableview.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        tableview.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         tableview.estimatedRowHeight = 25
         tableview.rowHeight = UITableView.automaticDimension
         tableview.separatorStyle = .none
@@ -530,7 +530,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         unreadScrollButton.isHidden = true
         unreadScrollButton.addTarget(self, action: #selector(unreadScrollDownAction(_:)), for: .touchUpInside)
 
-        backgroundView.backgroundColor = UIColor.dynamicColor(light: configuration.backgroundColor, dark: UIColor.backgroundDarkColor())
+        backgroundView.backgroundColor = UIColor.kmDynamicColor(light: configuration.backgroundColor, dark: configuration.backgroundDarkColor)
         prepareTable()
         if moreBar.isHidden{
             prepareMoreBar()
@@ -640,7 +640,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         conversationInfoView.topAnchor.constraint(equalTo: contextTitleView.bottomAnchor).isActive = true
         conversationInfoView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         conversationInfoView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
-        conversationInfoView.backgroundColor = configuration.conversationInfoModel?.backgroundColor
+        conversationInfoView.backgroundColor = UIColor.kmDynamicColor(light: configuration.conversationInfoModel?.backgroundColor ?? .gray, dark: configuration.conversationInfoModel?.darkBackgroundColor ?? .white)
         
         if configuration.conversationInfoModel == nil {
             conversationInfoView.heightAnchor.constraint(equalToConstant: 0).isActive = true
@@ -798,12 +798,12 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func prepareChatBar() {
         // Update ChatBar's top view which contains send button and the text view.
-        chatBar.grayView.backgroundColor = UIColor.dynamicColor(light: configuration.backgroundColor, dark: UIColor.backgroundDarkColor())
+        chatBar.grayView.backgroundColor = UIColor.kmDynamicColor(light: configuration.backgroundColor, dark: configuration.backgroundDarkColor)
 
         // Update background view's color which contains all the attachment options.
-        chatBar.bottomBackgroundColor = UIColor.dynamicColor(light: configuration.chatBarAttachmentViewBackgroundColor, dark: UIColor.appBarDarkColor())
+        chatBar.bottomBackgroundColor = UIColor.kmDynamicColor(light: configuration.chatBarAttachmentViewBackgroundColor, dark: configuration.chatBarAttachmentViewDarkBackgroundColor)
 
-        chatBar.textView.textColor = UIColor.dynamicColor(light: .white, dark: .black)
+        chatBar.textView.textColor = UIColor.kmDynamicColor(light: .white, dark: .black)
         chatBar.poweredByMessageTextView.hyperLink(mutableAttributedString: NSMutableAttributedString(string: "Powered by Kommunicate.io"),
                                                    url: URL(string: "https://kommunicate.io")!,
                                                    clickString: "Kommunicate.io")

--- a/Sources/Controllers/ALKCustomPickerViewController.swift
+++ b/Sources/Controllers/ALKCustomPickerViewController.swift
@@ -42,7 +42,7 @@ class ALKCustomPickerViewController: ALKBaseViewController, Localizable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = UIColor.dynamicColor(light: UIColor.white, dark: UIColor.appBarDarkColor())
+        view.backgroundColor = UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.appBarDarkColor())
         doneButton.title = localizedString(forKey: "DoneButton", withDefaultValue: SystemMessage.ButtonName.Done, fileName: localizedStringFileName)
         title = localizedString(forKey: "PhotosTitle", withDefaultValue: SystemMessage.LabelName.Photos, fileName: localizedStringFileName)
         checkPhotoLibraryPermission()

--- a/Sources/Controllers/ALKFormDatePickerViewController.swift
+++ b/Sources/Controllers/ALKFormDatePickerViewController.swift
@@ -65,7 +65,7 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
     private let popupTitle: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
-        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
+        label.textColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 3
         label.font = Font.bold(size: 18.0).font()
         return label
@@ -184,9 +184,9 @@ class ALKFormDatePickerViewController: UIViewController, Localizable {
     }
 
     private func setupViews() {
-        view.backgroundColor = UIColor.dynamicColor(light: UIColor(red: 10, green: 10, blue: 10, alpha: 0.2), dark: UIColor.appBarDarkColor())
-        modalView.backgroundColor = UIColor.dynamicColor(light: UIColor(red: 10, green: 10, blue: 10, alpha: 0.2), dark: UIColor.appBarDarkColor())
-        buttonUIView.backgroundColor = UIColor.dynamicColor(light: UIColor(red: 10, green: 10, blue: 10, alpha: 0.2), dark: UIColor.appBarDarkColor())
+        view.backgroundColor = UIColor.kmDynamicColor(light: UIColor(red: 10, green: 10, blue: 10, alpha: 0.2), dark: UIColor.appBarDarkColor())
+        modalView.backgroundColor = UIColor.kmDynamicColor(light: UIColor(red: 10, green: 10, blue: 10, alpha: 0.2), dark: UIColor.appBarDarkColor())
+        buttonUIView.backgroundColor = UIColor.kmDynamicColor(light: UIColor(red: 10, green: 10, blue: 10, alpha: 0.2), dark: UIColor.appBarDarkColor())
         view.isOpaque = false
         view.isUserInteractionEnabled = true
         uiDatePicker.datePickerMode = datePickerMode

--- a/Sources/Controllers/ALKMapViewController.swift
+++ b/Sources/Controllers/ALKMapViewController.swift
@@ -31,7 +31,7 @@ class ALKMapViewController: UIViewController, Localizable {
     }
 
     override func viewWillAppear(_: Bool) {
-        view.backgroundColor = UIColor.dynamicColor(light: UIColor.white, dark: UIColor.appBarDarkColor())
+        view.backgroundColor = UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.appBarDarkColor())
         title = localizedString(forKey: "ShareLocationTitle", withDefaultValue: SystemMessage.Map.ShareLocationTitle, fileName: configuration.localizedStringFileName)
         let locationButtonTitle = localizedString(forKey: "SendLocationButton", withDefaultValue: SystemMessage.Map.SendLocationButton, fileName: configuration.localizedStringFileName)
         shareLocationButton.setTitle(locationButtonTitle, for: UIControl.State.normal)

--- a/Sources/Controllers/ALKMultipleLanguageSelectionViewController.swift
+++ b/Sources/Controllers/ALKMultipleLanguageSelectionViewController.swift
@@ -19,7 +19,7 @@ class ALKMultipleLanguageSelectionViewController : UIViewController {
     var titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont(name: "HelveticaNeue-Bold", size: 16) ?? UIFont.systemFont(ofSize: 16)
-        label.textColor = UIColor(red: 96, green: 94, blue: 94)
+        label.textColor = UIColor.kmDynamicColor(light: UIColor(red: 96, green: 94, blue: 94), dark: .lightText)
         label.text = "Select a language"
         return label
     }()
@@ -102,7 +102,7 @@ class ALKMultipleLanguageSelectionViewController : UIViewController {
         titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16).isActive = true
         titleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16).isActive = true
        
-        closeButton.imageView?.tintColor = UIColor.black
+        closeButton.imageView?.tintColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         closeButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor).isActive = true
         closeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16).isActive = true
         closeButton.widthAnchor.constraint(equalToConstant: 30.0).isActive = true
@@ -113,7 +113,7 @@ class ALKMultipleLanguageSelectionViewController : UIViewController {
         languageStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
         bottomConstraint.isActive = true
 
-        view.backgroundColor = .white
+        view.backgroundColor = .kmDynamicColor(light: .white, dark: .backgroundDarkColor())
         view.layer.cornerRadius = 8
     }
 }

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -24,6 +24,9 @@ public struct ALKConfiguration {
 
     /// The background color of the ALKConversationViewController.
     public var backgroundColor = UIColor(netHex: 0xF9F9F9)
+    
+    /// The dark background color of the ALKConversationViewController.
+    public var backgroundDarkColor = UIColor(netHex: 0x1C1C1C)
 
     /// Hides the bottom line in the navigation bar.
     /// It will be hidden in all the ViewControllers where
@@ -33,6 +36,15 @@ public struct ALKConfiguration {
     /// ChatBar's bottom view color. This is the view which contains
     /// all the attachment and other options.
     public var chatBarAttachmentViewBackgroundColor = UIColor.background(.grayEF)
+    
+    /// ChatBar attachment view dark background color
+    public var chatBarAttachmentViewDarkBackgroundColor = UIColor(netHex: 0x313131)
+    
+    /// RecivedMessage Light Bubble Color
+    public var recivedMessageColor = UIColor.gray
+    
+    /// RecivedMessage dark Bubble Color
+    public var recivedMessageDarkColor = UIColor.red
 
     /// If true then audio option in chat bar will be hidden.
     public var hideAudioOptionInChatBar = false

--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -29,7 +29,7 @@ public enum ALKMessageStyle {
     // Received message text style
     public static var receivedMessage = Style(
         font: UIFont.font(.normal(size: 14)),
-        text: UIColor.dynamicColor(light: .text(.black00), dark: .text(.white))
+        text: UIColor.kmDynamicColor(light: .text(.black00), dark: .text(.white))
     )
 
     // Sent message text style
@@ -144,10 +144,10 @@ public enum ALKMessageStyle {
         }
     }
 
-    public static var receivedBubble = Bubble(color: UIColor.dynamicColor(light: UIColor(netHex: 0xF1F0F0), dark: UIColor.appBarDarkColor()), style: .edge) {
+    public static var receivedBubble = Bubble(color: UIColor.kmDynamicColor(light: UIColor(netHex: 0xF1F0F0), dark: UIColor.appBarDarkColor()), style: .edge) {
         didSet {
             let appSettingsUserDefaults = ALKAppSettingsUserDefaults()
-            appSettingsUserDefaults.setReceivedMessageBackgroundColor(color: UIColor.dynamicColor(light: receivedBubble.color, dark: UIColor.appBarDarkColor()))
+            appSettingsUserDefaults.setReceivedMessageBackgroundColor(color: UIColor.kmDynamicColor(light: receivedBubble.color, dark: UIColor.appBarDarkColor()))
         }
     }
 

--- a/Sources/ViewModels/KMConversationInfoViewModel.swift
+++ b/Sources/ViewModels/KMConversationInfoViewModel.swift
@@ -16,13 +16,25 @@ public class KMConversationInfoViewModel {
     var backgroundColor: UIColor
     var contentColor: UIColor
     var contentFont: UIFont?
+    var darkBackgroundColor: UIColor
+    var contentDarkColor: UIColor
     
-   public init(infoContent: String, leadingImage: UIImage, trailingImage: UIImage, backgroundColor: UIColor, contentColor: UIColor, contentFont: UIFont) {
+    public init(infoContent: String, leadingImage: UIImage, trailingImage: UIImage, backgroundColor: UIColor, contentColor: UIColor, contentFont: UIFont, darkBackgroundColor: UIColor = .clear, contentDarkColor: UIColor = .clear) {
         self.infoContent = infoContent
         self.leadingImage = leadingImage
         self.trailingImage = trailingImage
         self.backgroundColor = backgroundColor
         self.contentColor = contentColor
         self.contentFont = contentFont
+        if darkBackgroundColor == UIColor.clear {
+            self.darkBackgroundColor = backgroundColor
+        } else {
+            self.darkBackgroundColor = darkBackgroundColor
+        }
+        if contentDarkColor == UIColor.clear {
+            self.contentDarkColor = contentColor
+        } else {
+            self.contentDarkColor = contentDarkColor
+        }
     }
 }

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -217,7 +217,7 @@ open class ALKChatBar: UIView, Localizable {
     open var lineView: UIView = {
         let view = UIView()
         let layer = view.layer
-        view.backgroundColor = UIColor.dynamicColor(light: UIColor(red: 217.0 / 255.0, green: 217.0 / 255.0, blue: 217.0 / 255.0, alpha: 1.0), dark: UIColor.darkGray)
+        view.backgroundColor = UIColor.kmDynamicColor(light: UIColor(red: 217.0 / 255.0, green: 217.0 / 255.0, blue: 217.0 / 255.0, alpha: 1.0), dark: UIColor.darkGray)
         return view
     }()
 
@@ -774,7 +774,7 @@ open class ALKChatBar: UIView, Localizable {
 extension ALKChatBar: UITextViewDelegate {
     public func textViewDidChange(_ textView: UITextView) {
         textView.typingAttributes = defaultTextAttributes
-        textView.textColor = UIColor.dynamicColor(light: UIColor.black, dark: UIColor.white)
+        textView.textColor = UIColor.kmDynamicColor(light: UIColor.black, dark: UIColor.white)
         if textView.text.isEmpty {
             clearTextInTextView()
         } else {

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -152,7 +152,7 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
         label.lineBreakMode = .byTruncatingTail
         label.numberOfLines = 1
         label.font = Font.bold(size: 14.0).font()
-        label.textColor = UIColor.dynamicColor(light: .text(.black00), dark: .text(.white))
+        label.textColor = UIColor.kmDynamicColor(light: .text(.black00), dark: .text(.white))
         return label
     }()
     
@@ -246,8 +246,8 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
             return
         }
 
-        lineView.backgroundColor = UIColor.dynamicColor(light: UIColor(netHex: 0xF1F1F1), dark: UIColor.appBarDarkColor())
-        backgroundColor = highlighted ? UIColor.dynamicColor(light: UIColor(netHex: 0xECECEC), dark: UIColor.appBarDarkColor()) : UIColor.dynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
+        lineView.backgroundColor = UIColor.kmDynamicColor(light: UIColor(netHex: 0xF1F1F1), dark: UIColor.appBarDarkColor())
+        backgroundColor = highlighted ? UIColor.kmDynamicColor(light: UIColor(netHex: 0xECECEC), dark: UIColor.appBarDarkColor()) : UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
         contentView.backgroundColor = backgroundColor
 
         // set backgroundColor of badgeNumber
@@ -259,8 +259,8 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
         guard viewModel != nil else {
             return
         }
-        lineView.backgroundColor = UIColor.dynamicColor(light: UIColor(netHex: 0xF1F1F1), dark: UIColor.appBarDarkColor())
-        backgroundColor = selected ? UIColor.dynamicColor(light: UIColor(netHex: 0xECECEC), dark: UIColor.appBarDarkColor()) : UIColor.dynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
+        lineView.backgroundColor = UIColor.kmDynamicColor(light: UIColor(netHex: 0xF1F1F1), dark: UIColor.appBarDarkColor())
+        backgroundColor = selected ? UIColor.kmDynamicColor(light: UIColor(netHex: 0xECECEC), dark: UIColor.appBarDarkColor()) : UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
         contentView.backgroundColor = backgroundColor
 
         // set backgroundColor of badgeNumber

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -25,7 +25,7 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate, UI
     let itemListView = NestedCellTableView()
     var submitButton: CurvedImageButton?
     var identifier: String?
-    let formBorderColor: CGColor = UIColor.dynamicColor(light: UIColor(red: 230/255, green: 229/255, blue: 236/255, alpha: 1.0), dark: UIColor.darkGray).cgColor
+    let formBorderColor: CGColor = UIColor.kmDynamicColor(light: UIColor(red: 230/255, green: 229/255, blue: 236/255, alpha: 1.0), dark: UIColor.darkGray).cgColor
     var activeTextField: UITextField? {
         didSet {
             activeTextFieldChanged?(activeTextField)
@@ -126,11 +126,11 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate, UI
     func textViewDidBeginEditing(_ textView: UITextView) {
         activeTextView = textView
         textView.text = nil
-        textView.textColor = .dynamicColor(light: .black, dark: .white)
+        textView.textColor = .kmDynamicColor(light: .black, dark: .white)
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        textView.textColor = .dynamicColor(light: .black, dark: .white)
+        textView.textColor = .kmDynamicColor(light: .black, dark: .white)
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
@@ -154,7 +154,7 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate, UI
     }
 
     private func setUpTableView() {
-        itemListView.backgroundColor = UIColor.dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        itemListView.backgroundColor = UIColor.kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         itemListView.estimatedRowHeight = 50
         itemListView.estimatedSectionHeaderHeight = 50
         itemListView.rowHeight = UITableView.automaticDimension

--- a/Sources/Views/ALKFormDateItemCell.swift
+++ b/Sources/Views/ALKFormDateItemCell.swift
@@ -54,7 +54,7 @@ class ALKFormDateBaseCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 15).font()
-        label.textColor = .dynamicColor(light: .black, dark: .white)
+        label.textColor = .kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 1
         label.textAlignment = .left
         return label
@@ -68,7 +68,7 @@ class ALKFormDateBaseCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        valueTextField.textColor = .dynamicColor(light: .black, dark: .white)
+        valueTextField.textColor = .kmDynamicColor(light: .black, dark: .white)
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         addConstraints()

--- a/Sources/Views/ALKFormMultiSelectItemCell.swift
+++ b/Sources/Views/ALKFormMultiSelectItemCell.swift
@@ -22,7 +22,7 @@ class ALKFormMultiSelectItemCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 17).font()
-        label.textColor = .dynamicColor(light: .black, dark: .white)
+        label.textColor = .kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 0
         label.textAlignment = .left
         return label

--- a/Sources/Views/ALKFormPasswordItemCell.swift
+++ b/Sources/Views/ALKFormPasswordItemCell.swift
@@ -24,7 +24,7 @@ class ALKFormPasswordItemCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 15).font()
-        label.textColor = .dynamicColor(light: .black, dark: .white)
+        label.textColor = .kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 1
         label.textAlignment = .left
         return label
@@ -38,7 +38,7 @@ class ALKFormPasswordItemCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        valueTextField.textColor = .dynamicColor(light: .black, dark: .white)
+        valueTextField.textColor = .kmDynamicColor(light: .black, dark: .white)
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         addConstraints()

--- a/Sources/Views/ALKFormSingleSelectItemCell.swift
+++ b/Sources/Views/ALKFormSingleSelectItemCell.swift
@@ -22,7 +22,7 @@ class ALKFormSingleSelectItemCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 17).font()
-        label.textColor = .dynamicColor(light: .black, dark: .white)
+        label.textColor = .kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 0
         label.textAlignment = .left
         return label

--- a/Sources/Views/ALKFormTextItemCell.swift
+++ b/Sources/Views/ALKFormTextItemCell.swift
@@ -23,7 +23,7 @@ class ALKFormTextItemCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 15).font()
-        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
+        label.textColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 1
         label.textAlignment = .left
         return label
@@ -53,7 +53,7 @@ class ALKFormTextItemCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        valueTextField.textColor = .dynamicColor(light: .black, dark: .white)
+        valueTextField.textColor = .kmDynamicColor(light: .black, dark: .white)
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         addConstraints()
@@ -102,7 +102,7 @@ class ALKFormTextAreaItemCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 15).font()
-        label.textColor = UIColor.dynamicColor(light: .black, dark: .white)
+        label.textColor = UIColor.kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 1
         label.textAlignment = .left
         return label
@@ -135,7 +135,7 @@ class ALKFormTextAreaItemCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         valueTextField.textColor = .black
-        contentView.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        contentView.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         addConstraints()
     }
 
@@ -182,7 +182,7 @@ class ALKFormItemHeaderView: UITableViewHeaderFooterView {
     var titleLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.normal(size: 17).font()
-        label.textColor = .dynamicColor(light: .text(.gray7E), dark: .text(.grayCC))
+        label.textColor = .kmDynamicColor(light: .text(.gray7E), dark: .text(.grayCC))
         label.numberOfLines = 0
         label.textAlignment = .left
         return label

--- a/Sources/Views/ALKGenericCardCell.swift
+++ b/Sources/Views/ALKGenericCardCell.swift
@@ -86,17 +86,17 @@ open class ALKGenericCardCell: UICollectionViewCell {
     
     public enum Color {
         /// Used for overlay text color
-        public static var overlayTextColor = UIColor.dynamicColor(light: UIColor(red: 13, green: 13, blue: 14), dark: .text(.white))
+        public static var overlayTextColor = UIColor.kmDynamicColor(light: UIColor(red: 13, green: 13, blue: 14), dark: .text(.white))
         /// Used for rating text color
-        public static var ratingTextColor = UIColor.dynamicColor(light: UIColor(red: 0, green: 0, blue: 0), dark: UIColor(netHex: 0xC3C3C3))
+        public static var ratingTextColor = UIColor.kmDynamicColor(light: UIColor(red: 0, green: 0, blue: 0), dark: UIColor(netHex: 0xC3C3C3))
         /// Used for title text color
-        public static var titleTextColor = UIColor.dynamicColor(light: UIColor(red: 20, green: 19, blue: 19), dark: .text(.white))
+        public static var titleTextColor = UIColor.kmDynamicColor(light: UIColor(red: 20, green: 19, blue: 19), dark: .text(.white))
         /// Used for subtitle text color
-        public static var subtitleTextColor = UIColor.dynamicColor(light: UIColor(red: 86, green: 84, blue: 84), dark: UIColor(netHex: 0xF3F3F3))
+        public static var subtitleTextColor = UIColor.kmDynamicColor(light: UIColor(red: 86, green: 84, blue: 84), dark: UIColor(netHex: 0xF3F3F3))
         /// Used for description text color
-        public static var descriptionTextColor = UIColor.dynamicColor(light: UIColor(red: 121, green: 116, blue: 116), dark: UIColor(netHex: 0xC3C3C3))
+        public static var descriptionTextColor = UIColor.kmDynamicColor(light: UIColor(red: 121, green: 116, blue: 116), dark: UIColor(netHex: 0xC3C3C3))
         /// Used for background color of overlay text
-        public static var overlayTextBackground = UIColor.dynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
+        public static var overlayTextBackground = UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
         /// Shadow color of the overlay text
         public static var overlayTextShadowColor = UIColor.black.cgColor
     }
@@ -401,14 +401,14 @@ open class ALKGenericCardCell: UICollectionViewCell {
             button.setTitle("Button", for: .normal)
             button.addTarget(self, action: #selector(buttonSelected(_:)), for: .touchUpInside)
             button.tag = $0
-            button.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+            button.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
             return button
         }
     }
 
     private func setupConstraints() {
         let view = contentView
-        view.backgroundColor = UIColor.dynamicColor(light: UIColor.white, dark: UIColor.appBarDarkColor())
+        view.backgroundColor = UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.appBarDarkColor())
         titleStackView.addArrangedSubview(titleLabel)
         titleStackView.addArrangedSubview(ratingLabel)
         actionButtons.forEach {

--- a/Sources/Views/KMConversationInfoView.swift
+++ b/Sources/Views/KMConversationInfoView.swift
@@ -72,7 +72,7 @@ open class KMConversationInfoView: UIView {
         leadingImageView.image = viewModel.leadingImage
         trailingImageView.image = viewModel.trailingImage
         titleLabel.font = viewModel.contentFont ?? Font.normal(size: 16.0).font()
-        titleLabel.textColor = viewModel.contentColor
+        titleLabel.textColor = .kmDynamicColor(light: viewModel.contentColor, dark: viewModel.contentDarkColor)
     }
 
 }

--- a/Sources/Views/KMFormDropDownCell.swift
+++ b/Sources/Views/KMFormDropDownCell.swift
@@ -74,7 +74,7 @@ class KMFormDropDownCell: UITableViewCell {
     let nameLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = Font.medium(size: 17).font()
-        label.textColor = .dynamicColor(light: .black, dark: .white)
+        label.textColor = .kmDynamicColor(light: .black, dark: .white)
         label.numberOfLines = 0
         label.textAlignment = .left
         return label
@@ -88,7 +88,7 @@ class KMFormDropDownCell: UITableViewCell {
         dropdown.listHeight = FormDropDownStyle.Size.listHeight
         dropdown.textColor = FormDropDownStyle.Color.textColor
         dropdown.arrowSize = FormDropDownStyle.Size.arrowSize
-        dropdown.arrowColor = UIColor.dynamicColor(light: FormDropDownStyle.Color.arrowColor, dark: .white)
+        dropdown.arrowColor = UIColor.kmDynamicColor(light: FormDropDownStyle.Color.arrowColor, dark: .white)
         return dropdown
     }()
 
@@ -104,7 +104,7 @@ class KMFormDropDownCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         contentView.isUserInteractionEnabled = true
-        contentView.backgroundColor = UIColor.dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        contentView.backgroundColor = UIColor.kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
         menu.delegate = self
         addConstraints()
     }
@@ -163,8 +163,8 @@ extension KMFormDropDownCell: UITextFieldDelegate {
 public struct FormDropDownStyle {
     public struct Color {
         public static var selectedRowBackgroundColor : UIColor = UIColor.init(hexString: "#87CEFA")
-        public static var rowBackgroundColor: UIColor = UIColor.dynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
-        public static var textColor: UIColor = UIColor.dynamicColor(light: UIColor.gray, dark: UIColor.white)
+        public static var rowBackgroundColor: UIColor = UIColor.kmDynamicColor(light: UIColor.white, dark: UIColor.backgroundDarkColor())
+        public static var textColor: UIColor = UIColor.kmDynamicColor(light: UIColor.gray, dark: UIColor.white)
         public static var arrowColor: UIColor = .black
     }
     

--- a/Sources/Views/KMLanguageView.swift
+++ b/Sources/Views/KMLanguageView.swift
@@ -18,9 +18,9 @@ public class KMLanguageView: UIView {
         public static var dividerColor = UIColor.lightGray
         public static var minHeight: CGFloat = 35
         public static var padding = Padding(left: 14, right: 14, top: 4, bottom: 8)
-        public static var selectedBackgroundColor = UIColor(hexString: "686464", alpha: 1)
+        public static var selectedBackgroundColor = UIColor.kmDynamicColor(light: UIColor(hexString: "686464", alpha: 1), dark: .appBarDarkColor())
         public static var selectedNameTextColor = UIColor(hexString: "ffffff", alpha: 1)
-        public static var languageNameTextColor = UIColor(hexString: "29292a", alpha: 1)
+        public static var languageNameTextColor = UIColor.kmDynamicColor(light: UIColor(hexString: "29292a", alpha: 1), dark: .lightText)
         public static var languageNameFont = UIFont.systemFont(ofSize: 15)
         
         public enum LineStyle {

--- a/Sources/Views/ListTemplateView.swift
+++ b/Sources/Views/ListTemplateView.swift
@@ -93,8 +93,8 @@ class ListTemplateElementView: UIView {
 
     private func setupStyle() {
         let style = ALKListTemplateCell.ListStyle.shared
-        title.textColor = UIColor.dynamicColor(light: style.listTemplateElementViewStyle.titleTextColor, dark: .text(.white))
-        subtitle.textColor = UIColor.dynamicColor(light: style.listTemplateElementViewStyle.subtitleTextColor, dark: .text(.grayCC))
+        title.textColor = UIColor.kmDynamicColor(light: style.listTemplateElementViewStyle.titleTextColor, dark: .text(.white))
+        subtitle.textColor = UIColor.kmDynamicColor(light: style.listTemplateElementViewStyle.subtitleTextColor, dark: .text(.grayCC))
     }
 
     @objc private func tapped() {
@@ -280,7 +280,7 @@ class ListTemplateView: UIView {
             button.addTarget(self, action: #selector(buttonSelected(_:)), for: .touchUpInside)
             button.titleLabel?.numberOfLines = 1
             button.tag = $0
-            button.backgroundColor = .dynamicColor(light: buttonBackgroundColor, dark: UIColor.appBarDarkColor())
+            button.backgroundColor = .kmDynamicColor(light: buttonBackgroundColor, dark: UIColor.appBarDarkColor())
             button.layoutIfNeeded()
             return button
         }
@@ -290,7 +290,7 @@ class ListTemplateView: UIView {
         listItems = (0 ... 7).map {
             let item = ListTemplateElementView()
             item.tag = $0
-            item.backgroundColor = .dynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+            item.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
             item.selected = { [weak self] element in
                 guard let weakSelf = self, let selected = weakSelf.selected else { return }
                 selected(element,nil,element.action)
@@ -332,7 +332,7 @@ class ListTemplateView: UIView {
     }
 
     private func setupStyle() {
-        headerText.textColor = .dynamicColor(light: listStyle.headerText.text, dark: .white)
-        headerText.backgroundColor = .dynamicColor(light: listStyle.headerText.background, dark: UIColor.appBarDarkColor())
+        headerText.textColor = .kmDynamicColor(light: listStyle.headerText.text, dark: .white)
+        headerText.backgroundColor = .kmDynamicColor(light: listStyle.headerText.background, dark: UIColor.appBarDarkColor())
     }
 }


### PR DESCRIPTION
## Summary
- Added Customisation for dark color for  Conversation Background Color. 
```
Kommunicate.defaultConfiguration.backgroundDarkColor
```
- Added Customisation  for dark color for Conversation Screen Bottom Attachment bar Color. 
```
Kommunicate.defaultConfiguration.chatBarAttachmentViewBackgroundColor
```
- Added Customisation  for dark color Conversation Info Model added parameters with default values. 
```
KMConversationInfoViewModel(infoContent: "This is your conversation info text", leadingImage: leading, trailingImage:trailing, backgroundColor: bg, contentColor: UIColor.white, contentFont:font,darkBackgroundColor: .white, contentDarkColor: .black)
```
- Added Customisation for dark Color for FAQ Customisation. 
```
Kommunicate.kmConversationViewConfiguration.faqDarkBackgroundColor 
```
```
Kommunicate.kmConversationViewConfiguration.faqTextDarkColor
```
- Added Customisation for dark color for Start new Conversation bottom Button. 
```
Kommunicate.kmConversationViewConfiguration.startNewConversationButtonDarkBackgroundColor
```
```
Kommunicate.kmConversationViewConfiguration.startNewConversationButtonDarkTextColor
```
- Added dynamic color change support in "Speech to text Section".