### PR TITLE
[CM-1641] Fixed action buttons not hiding while hidePostCTA is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed action buttons not hiding while hidePostCTA is enabled
+
 ## [1.1.9] 2023-10-18
 - Fixed the Button Title hidding in smaller devices.
 - Changed foreground color for link present inside message.

--- a/RichMessageKit/Views/ReceivedButtonsCell.swift
+++ b/RichMessageKit/Views/ReceivedButtonsCell.swift
@@ -66,7 +66,7 @@ public class ReceivedButtonsCell: UITableViewCell {
         return lb
     }()
 
-    fileprivate lazy var buttons = SuggestedReplyView()
+    lazy var buttons = SuggestedReplyView()
     fileprivate lazy var messageView = MessageView(
         bubbleStyle: MessageTheme.receivedMessage.bubble,
         messageStyle: MessageTheme.receivedMessage.message,
@@ -142,7 +142,7 @@ public class ReceivedButtonsCell: UITableViewCell {
     /// - Parameters:
     ///   - model: object that conforms to `SuggestedReplyMessage`
     /// - Returns: exact height of the view.
-    public static func rowHeight(model: SuggestedReplyMessage) -> CGFloat {
+    public static func rowHeight(model: SuggestedReplyMessage, isActionButtonHidden: Bool) -> CGFloat {
         let isMessageEmpty = model.message.isMessageEmpty()
         var height: CGFloat = 0
 
@@ -159,8 +159,12 @@ public class ReceivedButtonsCell: UITableViewCell {
 
         let quickReplyViewWidth = ViewPadding.maxWidth -
             (ChatCellPadding.ReceivedMessage.QuickReply.left + ChatCellPadding.ReceivedMessage.Message.right + ViewPadding.AvatarImageView.leading + ViewPadding.AvatarImageView.width + ChatCellPadding.ReceivedMessage.Message.left)
+        
+        if !isActionButtonHidden {
+            height += SuggestedReplyView.rowHeight(model: model, maxWidth: quickReplyViewWidth)
+        }
+        
         return height
-            + SuggestedReplyView.rowHeight(model: model, maxWidth: quickReplyViewWidth)
             + ChatCellPadding.ReceivedMessage.QuickReply.top
             + ChatCellPadding.ReceivedMessage.QuickReply.bottom + timeLabelSize.height.rounded(.up)
             + ViewPadding.TimeLabel.bottom

--- a/RichMessageKit/Views/ReceivedButtonsCell.swift
+++ b/RichMessageKit/Views/ReceivedButtonsCell.swift
@@ -84,10 +84,6 @@ public class ReceivedButtonsCell: UITableViewCell {
         setupConstraints()
         backgroundColor = .clear
     }
-    
-    func hideActionButtons() {
-        buttons.hideActionButtons()
-    }
 
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
@@ -146,7 +142,7 @@ public class ReceivedButtonsCell: UITableViewCell {
     /// - Parameters:
     ///   - model: object that conforms to `SuggestedReplyMessage`
     /// - Returns: exact height of the view.
-    public static func rowHeight(model: SuggestedReplyMessage, isActionButtonHidden: Bool) -> CGFloat {
+    public static func rowHeight(model: SuggestedReplyMessage) -> CGFloat {
         let isMessageEmpty = model.message.isMessageEmpty()
         var height: CGFloat = 0
 
@@ -164,11 +160,8 @@ public class ReceivedButtonsCell: UITableViewCell {
         let quickReplyViewWidth = ViewPadding.maxWidth -
             (ChatCellPadding.ReceivedMessage.QuickReply.left + ChatCellPadding.ReceivedMessage.Message.right + ViewPadding.AvatarImageView.leading + ViewPadding.AvatarImageView.width + ChatCellPadding.ReceivedMessage.Message.left)
         
-        if !isActionButtonHidden {
-            height += SuggestedReplyView.rowHeight(model: model, maxWidth: quickReplyViewWidth)
-        }
-        
         return height
+            + SuggestedReplyView.rowHeight(model: model, maxWidth: quickReplyViewWidth)
             + ChatCellPadding.ReceivedMessage.QuickReply.top
             + ChatCellPadding.ReceivedMessage.QuickReply.bottom + timeLabelSize.height.rounded(.up)
             + ViewPadding.TimeLabel.bottom

--- a/RichMessageKit/Views/ReceivedButtonsCell.swift
+++ b/RichMessageKit/Views/ReceivedButtonsCell.swift
@@ -66,7 +66,7 @@ public class ReceivedButtonsCell: UITableViewCell {
         return lb
     }()
 
-    lazy var buttons = SuggestedReplyView()
+    fileprivate lazy var buttons = SuggestedReplyView()
     fileprivate lazy var messageView = MessageView(
         bubbleStyle: MessageTheme.receivedMessage.bubble,
         messageStyle: MessageTheme.receivedMessage.message,
@@ -83,6 +83,10 @@ public class ReceivedButtonsCell: UITableViewCell {
         buttons.delegate = self
         setupConstraints()
         backgroundColor = .clear
+    }
+    
+    func hideActionButtons() {
+        buttons.hideActionButtons()
     }
 
     @available(*, unavailable)

--- a/RichMessageKit/Views/core/SuggestedReplyView.swift
+++ b/RichMessageKit/Views/core/SuggestedReplyView.swift
@@ -16,6 +16,7 @@ import UIKit
 public class SuggestedReplyView: UIView {
     static var didTapSuggestedReply = false
     static var messageIdentifier = String()
+    static let hidePostCTA = "HidePostCTAEnabled"
 
     // MARK: Public properties
 
@@ -206,6 +207,19 @@ public class SuggestedReplyView: UIView {
         button.index = index
         return button
     }
+    
+    func hideActionButtons() {
+        SuggestedReplyView.didTapSuggestedReply = true
+        if let identifier = model?.message.identifier {
+            SuggestedReplyView.messageIdentifier = identifier
+        }
+        model?.suggestion.removeAll()
+        mainStackView.isHidden = true
+        guard let suggestedReplyMessage = model else {
+            return
+        }
+        setupSuggestedReplyButtons(suggestedReplyMessage, maxWidth: 0)
+    }
 }
 
 extension SuggestedReplyView: Tappable {
@@ -213,12 +227,5 @@ extension SuggestedReplyView: Tappable {
         guard let index = index, let suggestion = model?.suggestion[index] else { return }
         let replyToBeSend = suggestion.reply ?? title
         delegate?.didTap(index: index, title: replyToBeSend)
-
-        if UserDefaults.standard.bool(forKey: "HidePostCTAEnabled") {
-            SuggestedReplyView.didTapSuggestedReply = true
-            SuggestedReplyView.messageIdentifier = (model?.message.identifier)!
-            model?.suggestion.removeAll()
-            mainStackView.isHidden = true
-        }
     }
 }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -48,6 +48,8 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
             return UITableViewCell()
         }
         print("Cell updated at row: ", indexPath.row ,"section: ", indexPath.section, "and type is: ", message.messageType)
+        
+        let isActionButtonHidden = viewModel.isActionButtonHidden(message: message)
 
         switch message.messageType {
         case .text, .html, .email:
@@ -345,6 +347,9 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 guard let template = message.payloadFromMetadata() else {
                     return cell
                 }
+                if viewModel.isActionButtonHidden(message: message){
+                    cell.quickReplyView.hideActionButtons()
+                }
                 cell.quickReplySelected = { [weak self] index, title in
                     guard let weakSelf = self else { return }
                     weakSelf.quickReplySelected(
@@ -369,6 +374,9 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
                 cell.update(viewModel: message, maxWidth: UIScreen.main.bounds.width)
                 cell.update(chatBar: chatBar)
+                if isActionButtonHidden {
+                    cell.buttonView.hideActionButtons()
+                }
                 cell.buttonSelected = { [weak self] index, title in
                     guard let weakSelf = self else { return }
                     weakSelf.messageButtonSelected(
@@ -477,6 +485,9 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
             } else {
                 let cell: ReceivedButtonsCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.update(model: allButtons)
+                if isActionButtonHidden {
+                    cell.buttons.hideActionButtons()
+                }
                 cell.tapped = { [weak self] index, name in
                     guard let weakSelf = self else { return }
                     weakSelf.richButtonSelected(

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -486,7 +486,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 let cell: ReceivedButtonsCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.update(model: allButtons)
                 if isActionButtonHidden {
-                    cell.buttons.hideActionButtons()
+                    cell.hideActionButtons()
                 }
                 cell.tapped = { [weak self] index, name in
                     guard let weakSelf = self else { return }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -347,7 +347,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 guard let template = message.payloadFromMetadata() else {
                     return cell
                 }
-                if viewModel.isActionButtonHidden(message: message){
+                if isActionButtonHidden {
                     cell.quickReplyView.hideActionButtons()
                 }
                 cell.quickReplySelected = { [weak self] index, title in
@@ -374,9 +374,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)
                 cell.update(viewModel: message, maxWidth: UIScreen.main.bounds.width)
                 cell.update(chatBar: chatBar)
-                if isActionButtonHidden {
-                    cell.buttonView.hideActionButtons()
-                }
                 cell.buttonSelected = { [weak self] index, title in
                     guard let weakSelf = self else { return }
                     weakSelf.messageButtonSelected(
@@ -485,9 +482,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
             } else {
                 let cell: ReceivedButtonsCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
                 cell.update(model: allButtons)
-                if isActionButtonHidden {
-                    cell.hideActionButtons()
-                }
                 cell.tapped = { [weak self] index, name in
                     guard let weakSelf = self else { return }
                     weakSelf.richButtonSelected(

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2180,8 +2180,10 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             }
             
             if message.messageType == .allButtons ||
-               message.messageType == .quickReply ||
-               message.messageType == .button {
+                message.messageType == .button {
+                viewModel.messageModels.remove(at: messageIndex)
+                tableView.deleteSections([messageIndex], with: .automatic)
+            } else if message.messageType == .quickReply {
                 tableView.reloadSections([messageIndex], with: .automatic)
             }
         }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2162,7 +2162,30 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
                 return
             }
             self.tableView.reloadSections(IndexSet(integer: indexPath.section), with: .none)
+            let message = self.viewModel.messageModels[indexPath.section]
+            if UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA),
+               message.isMyMessage {
+                self.reloadProcessedMessages(index: indexPath.section)
+            }
         }
+    }
+    
+    func reloadProcessedMessages(index : Int){
+        
+        for messageIndex in stride(from: index-1, to: -1, by: -1){
+            let message = viewModel.messageModels[messageIndex]
+            
+            guard !message.isMyMessage else {
+                return
+            }
+            
+            if message.messageType == .allButtons ||
+               message.messageType == .quickReply ||
+               message.messageType == .button {
+                tableView.reloadSections([messageIndex], with: .automatic)
+            }
+        }
+        moveTableViewToBottom(indexPath: IndexPath(row: 0, section: tableView.numberOfSections - 1))
     }
 
     // This is a temporary workaround for the issue that messages are not scrolling to bottom when opened from notification

--- a/Sources/Models/ALKMessageModel.swift
+++ b/Sources/Models/ALKMessageModel.swift
@@ -68,6 +68,7 @@ public protocol ALKMessageViewModel {
     var metadata: [String: Any]? { get }
     var source: Int16 { get }
     var contentType: Message.ContentType { get }
+    var createdAtTime : NSNumber? { get set }
 }
 
 public class ALKMessageModel: ALKMessageViewModel {
@@ -101,6 +102,7 @@ public class ALKMessageModel: ALKMessageViewModel {
     public var isReplyMessage: Bool = false
     public var metadata: [String: Any]?
     public var source: Int16 = 0
+    public var createdAtTime: NSNumber?
 }
 
 extension ALKMessageModel: Equatable {

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -469,6 +469,7 @@ public extension ALMessage {
         messageModel.isReplyMessage = isAReplyMessage()
         messageModel.metadata = metadata as? [String: Any]
         messageModel.source = source
+        messageModel.createdAtTime = createdAtTime
         if let messageContentType = Message.ContentType(rawValue: contentType) {
             messageModel.contentType = messageContentType
         }

--- a/Sources/Views/ALKFriendMessageQuickReplyCell.swift
+++ b/Sources/Views/ALKFriendMessageQuickReplyCell.swift
@@ -131,7 +131,7 @@ public class ALKFriendMessageQuickReplyCell: ALKChatBaseCell<ALKMessageViewModel
         quickReplyView.update(model: suggestedReplies, maxWidth: quickReplyViewWidth)
     }
 
-    public class func rowHeight(viewModel: ALKMessageViewModel, maxWidth: CGFloat) -> CGFloat {
+    public class func rowHeight(viewModel: ALKMessageViewModel, maxWidth: CGFloat, isActionButtonHidden: Bool) -> CGFloat {
         let isMessageEmpty = viewModel.isMessageEmpty
         var height: CGFloat = 0
 
@@ -155,8 +155,12 @@ public class ALKFriendMessageQuickReplyCell: ALKChatBaseCell<ALKMessageViewModel
 
         let quickReplyViewWidth = maxWidth -
             (ChatCellPadding.ReceivedMessage.QuickReply.left + ChatCellPadding.ReceivedMessage.Message.right + ViewPadding.AvatarImageView.leading + ViewPadding.AvatarImageView.width + ChatCellPadding.ReceivedMessage.Message.left)
+        
+        if !isActionButtonHidden {
+            height += SuggestedReplyView.rowHeight(model: suggestedReplies, maxWidth: quickReplyViewWidth)
+        }
+        
         return height
-            + SuggestedReplyView.rowHeight(model: suggestedReplies, maxWidth: quickReplyViewWidth)
             + ChatCellPadding.ReceivedMessage.QuickReply.top
             + ChatCellPadding.ReceivedMessage.QuickReply.bottom + timeLabelSize.height.rounded(.up)
             + ViewPadding.TimeLabel.bottom

--- a/Sources/Views/ALKMessageButtonCell.swift
+++ b/Sources/Views/ALKMessageButtonCell.swift
@@ -280,7 +280,7 @@ class ALKFriendMessageButtonCell: ALKChatBaseCell<ALKMessageViewModel> {
         buttonView.update(model: dict, maxWidth: buttonWidth)
     }
 
-    override open class func rowHeigh(viewModel: ALKMessageViewModel, width: CGFloat) -> CGFloat {
+    open class func rowHeigh(viewModel: ALKMessageViewModel, width: CGFloat, isActionButtonHidden: Bool) -> CGFloat {
         let isMessageEmpty = viewModel.isMessageEmpty
         var height: CGFloat = 0
 
@@ -304,9 +304,12 @@ class ALKFriendMessageButtonCell: ALKChatBaseCell<ALKMessageViewModel> {
         }
 
         let buttonWidth = width - (ChatCellPadding.ReceivedMessage.MessageButton.left + ChatCellPadding.ReceivedMessage.MessageButton.right)
-        let buttonHeight = SuggestedReplyView.rowHeight(model: dict, maxWidth: buttonWidth)
+        
+        if !isActionButtonHidden {
+            height += SuggestedReplyView.rowHeight(model: dict, maxWidth: buttonWidth)
+        }
+        
         return height
-            + buttonHeight
             + ChatCellPadding.ReceivedMessage.MessageButton.top
             + ChatCellPadding.ReceivedMessage.MessageButton.bottom + timeLabelSize.height.rounded(.up)
             + ViewPadding.TimeLabel.bottom

--- a/Sources/Views/ALKMessageButtonCell.swift
+++ b/Sources/Views/ALKMessageButtonCell.swift
@@ -280,7 +280,7 @@ class ALKFriendMessageButtonCell: ALKChatBaseCell<ALKMessageViewModel> {
         buttonView.update(model: dict, maxWidth: buttonWidth)
     }
 
-    open class func rowHeigh(viewModel: ALKMessageViewModel, width: CGFloat, isActionButtonHidden: Bool) -> CGFloat {
+    open override class func rowHeigh(viewModel: ALKMessageViewModel, width: CGFloat) -> CGFloat {
         let isMessageEmpty = viewModel.isMessageEmpty
         var height: CGFloat = 0
 
@@ -305,11 +305,8 @@ class ALKFriendMessageButtonCell: ALKChatBaseCell<ALKMessageViewModel> {
 
         let buttonWidth = width - (ChatCellPadding.ReceivedMessage.MessageButton.left + ChatCellPadding.ReceivedMessage.MessageButton.right)
         
-        if !isActionButtonHidden {
-            height += SuggestedReplyView.rowHeight(model: dict, maxWidth: buttonWidth)
-        }
-        
         return height
+            + SuggestedReplyView.rowHeight(model: dict, maxWidth: buttonWidth)
             + ChatCellPadding.ReceivedMessage.MessageButton.top
             + ChatCellPadding.ReceivedMessage.MessageButton.bottom + timeLabelSize.height.rounded(.up)
             + ViewPadding.TimeLabel.bottom


### PR DESCRIPTION
## Summary

Previously when the hidePostCTA was enabled and the user clicked on any suggested reply, the buttons were hiding but a space for that buttons was left behind which is fixed here. Now hidePostCTA is available for both buttons i.e, `Quick Replies` and `Submit button`

### Before

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/8fb39366-4e63-457a-804b-d3abb295f6cb" alt="before" width="300" height="525">

### After

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/a620fb6b-1259-4b1b-9e4f-0af1d457b907" alt="after" width="300" height="525">