### PR TITLE
[CM-1641] Added hidePostCTA support for different types of buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Added hidepostCTA support for all types of buttons.
+
 ## [1.1.9] 2023-10-18
 - Fixed the Button Title hidding in smaller devices.
 - Changed foreground color for link present inside message.

--- a/RichMessageKit/Models/SuggestedReplyMessage.swift
+++ b/RichMessageKit/Models/SuggestedReplyMessage.swift
@@ -11,6 +11,7 @@ public struct SuggestedReplyMessage {
     public enum SuggestionType {
         case link
         case normal
+        case submit
     }
 
     public struct Suggestion {

--- a/RichMessageKit/Views/core/SuggestedReplyView.swift
+++ b/RichMessageKit/Views/core/SuggestedReplyView.swift
@@ -16,6 +16,7 @@ import UIKit
 public class SuggestedReplyView: UIView {
     static var didTapSuggestedReply = false
     static var messageIdentifier = String()
+    static let hidePostCTA = "HidePostCTAEnabled"
 
     // MARK: Public properties
 
@@ -213,12 +214,5 @@ extension SuggestedReplyView: Tappable {
         guard let index = index, let suggestion = model?.suggestion[index] else { return }
         let replyToBeSend = suggestion.reply ?? title
         delegate?.didTap(index: index, title: replyToBeSend)
-
-        if UserDefaults.standard.bool(forKey: "HidePostCTAEnabled") {
-            SuggestedReplyView.didTapSuggestedReply = true
-            SuggestedReplyView.messageIdentifier = (model?.message.identifier)!
-            model?.suggestion.removeAll()
-            mainStackView.isHidden = true
-        }
     }
 }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -301,9 +301,6 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 return cell
             } else {
                 var cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as ALKFriendGenericCardMessageCell
-                if UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) {
-                    cell = ALKFriendGenericCardMessageCell()
-                }
                 cell.menuOptionsToShow = configuration.messageMenuOptions
                 cell.showReport = true
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -300,7 +300,10 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 return cell
             } else {
-                let cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as ALKFriendGenericCardMessageCell
+                var cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as ALKFriendGenericCardMessageCell
+                if UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) {
+                    cell = ALKFriendGenericCardMessageCell()
+                }
                 cell.menuOptionsToShow = configuration.messageMenuOptions
                 cell.showReport = true
                 cell.setLocalizedStringFileName(configuration.localizedStringFileName)

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2216,8 +2216,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
                 return
             }
             
-            if message.isSuggestedReply(),
-               !containsOnlyNormalButton(message: message) {
+            if message.isSuggestedReply() {
                 tableView.reloadSections([messageIndex], with: .automatic)
             }
         }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2330,7 +2330,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         tableView.beginUpdates()
         tableView.insertSections(IndexSet(integer: indexPath.section), with: .automatic)
         tableView.endUpdates()
-        reloadProcessedMessages(index: indexPath.section)
+        if UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) {
+            reloadProcessedMessages(index: indexPath.section)
+        }
         moveTableViewToBottom(indexPath: indexPath)
     }
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2181,7 +2181,76 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
                 return
             }
             self.tableView.reloadSections(IndexSet(integer: indexPath.section), with: .none)
+            let message = self.viewModel.messageModels[indexPath.section]
+            if UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA),
+               message.isMyMessage {
+                self.deleteProcessedMessages(index: indexPath.section)
+            }
         }
+    }
+    
+    func deleteProcessedMessages(index : Int){
+        
+        for messageIndex in stride(from: index-1, to: -1, by: -1){
+            let message = viewModel.messageModels[messageIndex]
+            
+            guard !message.isMyMessage else {
+                return
+            }
+            
+            if message.isSuggestedReply() &&
+                containsOnlyNormalButton(message: message) {
+                viewModel.messageModels.remove(at: messageIndex)
+                tableView.deleteSections([messageIndex], with: .automatic)
+            }
+        }
+        moveTableViewToBottom(indexPath: IndexPath(row: 0, section: tableView.numberOfSections - 1))
+    }
+    
+    func reloadProcessedMessages(index : Int){
+        
+        for messageIndex in stride(from: index-1, to: -1, by: -1){
+            let message = viewModel.messageModels[messageIndex]
+            
+            guard !message.isMyMessage else {
+                return
+            }
+            
+            if message.isSuggestedReply(),
+               !containsOnlyNormalButton(message: message) {
+                tableView.reloadSections([messageIndex], with: .automatic)
+            }
+        }
+        moveTableViewToBottom(indexPath: IndexPath(row: 0, section: tableView.numberOfSections - 1))
+    }
+    
+    func containsOnlyNormalButton(message : ALKMessageModel) -> Bool {
+        
+        guard message.message == nil else {
+            return false
+        }
+        
+        var buttons = message.linkOrSubmitButton()?.suggestion
+        if let buttons = buttons{
+            for button in buttons {
+                if button.type == .link ||
+                    button.type == .submit{
+                    return false
+                }
+            }
+        }
+        
+        buttons = message.allButtons()?.suggestion
+        if let buttons = buttons{
+            for button in buttons {
+                if button.type == .link ||
+                    button.type == .submit{
+                    return false
+                }
+            }
+        }
+        
+        return true
     }
 
     // This is a temporary workaround for the issue that messages are not scrolling to bottom when opened from notification
@@ -2261,6 +2330,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         tableView.beginUpdates()
         tableView.insertSections(IndexSet(integer: indexPath.section), with: .automatic)
         tableView.endUpdates()
+        reloadProcessedMessages(index: indexPath.section)
         moveTableViewToBottom(indexPath: indexPath)
     }
 

--- a/Sources/Models/ALKMessageModel.swift
+++ b/Sources/Models/ALKMessageModel.swift
@@ -68,6 +68,7 @@ public protocol ALKMessageViewModel {
     var metadata: [String: Any]? { get }
     var source: Int16 { get }
     var contentType: Message.ContentType { get }
+    var createdAtTime : NSNumber? { get set }
 }
 
 public class ALKMessageModel: ALKMessageViewModel {
@@ -101,6 +102,7 @@ public class ALKMessageModel: ALKMessageViewModel {
     public var isReplyMessage: Bool = false
     public var metadata: [String: Any]?
     public var source: Int16 = 0
+    public var createdAtTime: NSNumber?
 }
 
 extension ALKMessageModel: Equatable {

--- a/Sources/Models/CardTemplate.swift
+++ b/Sources/Models/CardTemplate.swift
@@ -13,7 +13,7 @@ public struct CardTemplate: Codable {
     public let subtitle: String?
     public let description: String?
     public let header: Header?
-    public let buttons: [Button]?
+    public var buttons: [Button]?
 
     public struct Header: Codable {
         public let imgSrc: String?

--- a/Sources/Models/ListTemplateModel.swift
+++ b/Sources/Models/ListTemplateModel.swift
@@ -12,7 +12,7 @@ public struct ListTemplate: Codable {
     public let headerImgSrc: String?
     public let headerText: String?
     public let elements: [Element]?
-    public let buttons: [Button]?
+    public var buttons: [Button]?
 
     public struct Element: Codable {
         public let imgSrc: String?

--- a/Sources/Utilities/ALKMessageViewModel+Extension.swift
+++ b/Sources/Utilities/ALKMessageViewModel+Extension.swift
@@ -170,7 +170,8 @@ extension ALKMessageViewModel {
     }
     
     func isSuggestedReply() -> Bool {
-        return self.messageType == .allButtons || self.messageType == .quickReply
+        let messageType = self.messageType
+        return messageType == .allButtons || messageType == .quickReply || messageType == .cardTemplate || messageType == .listTemplate
     }
     
     func isActionButtonHidden() -> Bool {

--- a/Sources/Utilities/ALKMessageViewModel+Extension.swift
+++ b/Sources/Utilities/ALKMessageViewModel+Extension.swift
@@ -119,6 +119,9 @@ extension ALKMessageViewModel {
         let isActionButtonHidden = isActionButtonHidden()
         guard let payload = payloadFromMetadata() else { return nil }
         var buttons = [SuggestedReplyMessage.Suggestion]()
+        if isActionButtonHidden {
+            return SuggestedReplyMessage(suggestion: buttons, message: messageDetails())
+        }
         for object in payload {
             guard let name = object["title"] as? String else { continue }
             let reply = object["message"] as? String
@@ -167,17 +170,17 @@ extension ALKMessageViewModel {
     }
     
     func isSuggestedReply() -> Bool {
-        guard self.messageType == .allButtons ||
-                self.messageType == .button ||
-                self.messageType == .quickReply else {
-            return false
-        }
-        return true
+        return self.messageType == .allButtons || self.messageType == .quickReply
     }
     
     func isActionButtonHidden() -> Bool {
+        
         guard UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA),
-              self.isSuggestedReply(),
+              self.messageType != .button else {
+            return false
+        }
+
+        guard self.isSuggestedReply(),
               let currentMessageTime = self.createdAtTime,
               let lastSentMessageTime = ALKConversationViewModel.lastSentMessage?.createdAtTime,
               currentMessageTime .int64Value < lastSentMessageTime .int64Value else {

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -469,6 +469,7 @@ public extension ALMessage {
         messageModel.isReplyMessage = isAReplyMessage()
         messageModel.metadata = metadata as? [String: Any]
         messageModel.source = source
+        messageModel.createdAtTime = createdAtTime
         if let messageContentType = Message.ContentType(rawValue: contentType) {
             messageModel.contentType = messageContentType
         }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -402,7 +402,6 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 return
                     ALKFriendMessageQuickReplyCell
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
-                        .cached(with: cacheIdentifier)
             }
         case .button:
             if messageModel.isMyMessage {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -184,7 +184,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         guard !alMessageWrapper.contains(message: message) else { return }
         alMessageWrapper.addALMessage(toMessageArray: message)
         alMessages.append(message)
-        messageModels.append(message.messageModel)
+        self.addMessageToMessageModel(messages: [message.messageModel])
         if(message.isMyMessage){
             ALKConversationViewModel.lastSentMessage = message
         }
@@ -382,7 +382,6 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 return
                     ALKFriendGenericCardMessageCell
                         .rowHeigh(viewModel: messageModel, width: maxWidth)
-                        .cached(with: cacheIdentifier)
             }
         case .faqTemplate:
             guard let faqMessage = messageModel.faqMessage() else { return 0 }
@@ -425,7 +424,6 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 return
                     ALKFriendMessageListTemplateCell
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
-                        .cached(with: cacheIdentifier)
             }
         case .document:
             if messageModel.isMyMessage {
@@ -640,7 +638,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         _ = sortedArray.map { self.alMessageWrapper.addALMessage(toMessageArray: $0) }
         alMessages.append(contentsOf: sortedArray)
         let models = sortedArray.map { $0.messageModel }
-        messageModels.append(contentsOf: models)
+        self.addMessageToMessageModel(messages: models)
         print("new messages: ", models.map { $0.message })
         delegate?.newMessagesAdded()
     }
@@ -1408,7 +1406,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             if self.isConversationAssignedToBot() && (self.botDelayTime > 0) && !self.isOldConversation() {
                 self.showTypingIndicatorForWelcomeMessage()
             } else {
-                self.addMessageToMessageModel(messages: self.modelsToBeAddedAfterDelay)
+                self.messageModels = self.modelsToBeAddedAfterDelay
             }
             self.membersInGroup { members in
                 self.groupMembers = members
@@ -1441,7 +1439,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             guard welcomeMessagePosition < modelsToBeAddedAfterDelay.count else{
                 return
             }
-            self.messageModels.append(modelsToBeAddedAfterDelay[welcomeMessagePosition])
+            self.addMessageToMessageModel(messages: [modelsToBeAddedAfterDelay[welcomeMessagePosition]])
             self.delegate?.messageUpdated()
             self.timer.invalidate()
             if welcomeMessagePosition >= alMessages.count  {
@@ -1633,7 +1631,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
     func addMessageToMessageModel(messages : [ALKMessageModel]){
         guard let lastSentMessageTime = ALKConversationViewModel.lastSentMessage?.createdAtTime,
               UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) else {
-            self.messageModels.insert(contentsOf: messages, at: 0)
+            self.messageModels.append(contentsOf: messages)
             return
         }
 

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -49,6 +49,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
 
     open var isSearch: Bool = false
     open var lastMessage : ALMessage?
+    internal static var lastSentMessage : ALMessage?
 
     // For topic based chat
     open var conversationProxy: ALConversationProxy? {
@@ -183,6 +184,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
         alMessageWrapper.addALMessage(toMessageArray: message)
         alMessages.append(message)
         messageModels.append(message.messageModel)
+        if(message.isMyMessage){
+            ALKConversationViewModel.lastSentMessage = message
+        }
     }
 
     func clearViewModel() {
@@ -296,7 +300,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
     open func heightForRow(indexPath: IndexPath, cellFrame _: CGRect, configuration: ALKConfiguration) -> CGFloat {
         let messageModel = messageModels[indexPath.section]
         let cacheIdentifier = (messageModel.isMyMessage ? "s-" : "r-") + messageModel.identifier
-        if let height = HeightCache.shared.getHeight(for: cacheIdentifier) {
+        let isActionButtonHidden = messageModel.isActionButtonHidden()
+        if let height = HeightCache.shared.getHeight(for: cacheIdentifier),
+           !isActionButtonHidden {
             return height
         }
         switch messageModel.messageType {
@@ -1389,6 +1395,10 @@ open class ALKConversationViewModel: NSObject, Localizable {
             if !KMConversationScreenConfiguration.staticTopMessage.isEmpty {
                 self.alMessages.insert(self.getInitialStaticFirstMessage(), at: 0)
             }
+            
+            if(ALKConversationViewModel.lastSentMessage == nil){
+                ALKConversationViewModel.lastSentMessage = self.getLastSentMessage()
+            }
 
             self.alMessageWrapper.addObject(toMessageArray: messages)
             
@@ -1397,8 +1407,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             if self.isConversationAssignedToBot() && (self.botDelayTime > 0) && !self.isOldConversation() {
                 self.showTypingIndicatorForWelcomeMessage()
             } else {
-                self.messageModels = self.modelsToBeAddedAfterDelay
-               
+                self.addMessageToMessageModel(messages: self.modelsToBeAddedAfterDelay)
             }
             self.membersInGroup { members in
                 self.groupMembers = members
@@ -1411,6 +1420,16 @@ open class ALKConversationViewModel: NSObject, Localizable {
     /*
         Since we are getting the welcome message from Api Call, we are using this method to Show Typing Delay Indicator for Welcome Messsages
      */
+    
+    func getLastSentMessage() -> ALMessage? {
+        for message in alMessages.reversed() {
+            if(message.isMyMessage){
+                return message
+            }
+        }
+        return nil
+    }
+    
     func showTypingIndicatorForWelcomeMessage() {
         if welcomeMessagePosition >= alMessages.count {
             return
@@ -1593,8 +1612,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
             self.alMessages.insert(contentsOf: messages as! [ALMessage], at: 0)
 
             self.alMessageWrapper.addObject(toMessageArray: messages)
+            if(ALKConversationViewModel.lastSentMessage == nil){
+                ALKConversationViewModel.lastSentMessage = self.getLastSentMessage()
+            }
             let models = messages.map { ($0 as! ALMessage).messageModel }
-            self.messageModels.insert(contentsOf: models, at: 0)
+            self.addMessageToMessageModel(messages: models)
             if isFirstTime {
                 self.membersInGroup { members in
                     self.groupMembers = members
@@ -1605,6 +1627,27 @@ open class ALKConversationViewModel: NSObject, Localizable {
             }
         })
         self.lastMessage = alMessages.last
+    }
+    
+    func addMessageToMessageModel(messages : [ALKMessageModel]){
+        guard let lastSentMessageTime = ALKConversationViewModel.lastSentMessage?.createdAtTime,
+              UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) else {
+            self.messageModels.insert(contentsOf: messages, at: 0)
+            return
+        }
+
+        for message in messages {
+            if let currentMessageTime = message.createdAtTime {
+                if message.isMyMessage ||
+                    message.message != nil ||
+                    message.linkOrSubmitButton()?.suggestion.count ?? 0 > 0 ||
+                    message.suggestedReply()?.suggestion.count ?? 0 > 0 ||
+                    message.allButtons()?.suggestion.count ?? 0 > 0 ||
+                    currentMessageTime .int64Value >= lastSentMessageTime .int64Value {
+                    self.messageModels.append(message)
+                }
+            }
+        }
     }
 
     open func loadOpenGroupMessages() {
@@ -1722,7 +1765,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 }
                 self.alMessageWrapper.getUpdatedMessageArray().insert(newMessages, at: 0)
                 self.alMessages.insert(mesg, at: 0)
-                self.messageModels.insert(mesg.messageModel, at: 0)
+                self.addMessageToMessageModel(messages: [mesg.messageModel])
             }
             self.delegate?.loadingFinished(error: nil)
         })

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -150,6 +150,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         self.conversationProxy = conversationProxy
         self.localizedStringFileName = localizedStringFileName
         self.prefilledMessage = prefilledMessage
+        ALKConversationViewModel.lastSentMessage = nil
     }
 
     // MARK: - Public methods

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -382,6 +382,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 return
                     ALKFriendGenericCardMessageCell
                         .rowHeigh(viewModel: messageModel, width: maxWidth)
+                        .cached(with: cacheIdentifier)
             }
         case .faqTemplate:
             guard let faqMessage = messageModel.faqMessage() else { return 0 }
@@ -401,6 +402,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 return
                     ALKFriendMessageQuickReplyCell
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
+                        .cached(with: cacheIdentifier)
             }
         case .button:
             if messageModel.isMyMessage {
@@ -424,6 +426,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 return
                     ALKFriendMessageListTemplateCell
                         .rowHeight(viewModel: messageModel, maxWidth: UIScreen.main.bounds.width)
+                        .cached(with: cacheIdentifier)
             }
         case .document:
             if messageModel.isMyMessage {

--- a/Sources/Views/ALKGenericCardCell.swift
+++ b/Sources/Views/ALKGenericCardCell.swift
@@ -304,6 +304,7 @@ open class ALKGenericCardCell: UICollectionViewCell {
             buttonStackView.isHidden = true
             return
         }
+        buttonStackView.isHidden = false
         updateViewFor(buttons)
         contentView.layoutIfNeeded()
     }

--- a/Sources/Views/ALKGenericCardCell.swift
+++ b/Sources/Views/ALKGenericCardCell.swift
@@ -39,7 +39,14 @@ open class ALKGenericCardCollectionView: ALKIndexedCollectionView {
         switch templateId {
         case ActionableMessageType.cardTemplate.rawValue:
             do {
-                let templates = try TemplateDecoder.decode([CardTemplate].self, from: metadata)
+                var templates = try TemplateDecoder.decode([CardTemplate].self, from: metadata)
+                if message.isActionButtonHidden() {
+                    for index in 0...templates.count - 1 {
+                        templates[index].buttons?.removeAll{ button in
+                            return button.action?.type != "link" && button.action?.type != "submit"
+                        }
+                    }
+                }
                 return templates
             } catch {
                 print("\(error)")

--- a/Sources/Views/ALKListTemplateCell.swift
+++ b/Sources/Views/ALKListTemplateCell.swift
@@ -362,11 +362,16 @@ public class ALKListTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
 
     public func update(viewModel: ALKMessageViewModel, maxWidth _: CGFloat) {
         guard let metadata = viewModel.metadata,
-              let template = try? TemplateDecoder.decode(ListTemplate.self, from: metadata)
+              var template = try? TemplateDecoder.decode(ListTemplate.self, from: metadata)
         else {
             listTemplateView.isHidden = true
             layoutIfNeeded()
             return
+        }
+        if viewModel.isActionButtonHidden() {
+            template.buttons?.removeAll{ button in
+                return button.action?.type != "link" && button.action?.type != "submit"
+            }
         }
         listTemplateView.isHidden = false
         listTemplateView.update(item: template)
@@ -376,9 +381,14 @@ public class ALKListTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
 
     public class func rowHeight(viewModel: ALKMessageViewModel, maxWidth _: CGFloat) -> CGFloat {
         guard let metadata = viewModel.metadata,
-              let template = try? TemplateDecoder.decode(ListTemplate.self, from: metadata)
+              var template = try? TemplateDecoder.decode(ListTemplate.self, from: metadata)
         else {
             return CGFloat(0)
+        }
+        if viewModel.isActionButtonHidden() {
+            template.buttons?.removeAll{ button in
+                return button.action?.type != "link" && button.action?.type != "submit"
+            }
         }
         return ListTemplateView.rowHeight(template: template)
     }


### PR DESCRIPTION
## Summary

- Added hidePostCTA support for all types of buttons
- Previously when the hidePostCTA was enabled and the user clicked on any suggested reply, the buttons were hiding but a space for that buttons was left behind which is also fixed

### Before

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/8fb39366-4e63-457a-804b-d3abb295f6cb" alt="before" width="300" height="525">

### After

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139108613/cf49a709-0b6b-4b41-b305-37ae6ca6c941" alt="after" width="300" height="525">