### PR TITLE
[CM-1663] Fixed Multiple selection(with new UI) buttons are getting cut in form template 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed buttons are getting cut in form template
+
 ## [1.2.0] 2023-10-27
 - Fixed Button Spacing
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -311,6 +311,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             let msgArray = notification.object as? [ALMessage]
             guard let list = notification.object as? [Any], !list.isEmpty, weakSelf.isViewLoaded else { return }
             weakSelf.addMessagesToList(list)
+            weakSelf.newFormMessageAdded()
         })
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: "notificationIndividualChat"), object: nil, queue: nil, using: {
             _ in
@@ -2220,6 +2221,13 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         tableView.endUpdates()
     }
 
+    @objc open func newFormMessageAdded() {
+        let indexPath = IndexPath(row: 0, section: viewModel.messageModels.count - 1)
+        if let lastMessage = viewModel.messageModels.last {
+            reloadIfFormMessage(message: lastMessage, indexPath: indexPath)
+        }
+    }
+    
     @objc open func newMessagesAdded() {
         let lastSectionBeforeUpdate = tableView.lastSection()
         updateTableView()

--- a/Sources/Utilities/KMMultipleSelectionConfiguration.swift
+++ b/Sources/Utilities/KMMultipleSelectionConfiguration.swift
@@ -21,7 +21,7 @@ public struct KMMultipleSelectionConfiguration {
     
     public var selectedBackgroundColor: UIColor = UIColor(hexString: "D4F3F8")
     
-    public var selectedFont: UIFont = Font.bold(size: 16).font()
+    public var selectedFont: UIFont = Font.bold(size: 15).font()
     
     public var cornorRadius: CGFloat = 7
     

--- a/Sources/Views/KMFormMultiSelectButtonItemCell.swift
+++ b/Sources/Views/KMFormMultiSelectButtonItemCell.swift
@@ -53,8 +53,8 @@ class KMFormMultiSelectButtonItemCell: UITableViewCell {
 private extension KMFormMultiSelectButtonItemCell {
     enum Size {
         enum nameLabel {
-            static let top: CGFloat = 10
-            static let bottom: CGFloat = -10
+            static let top: CGFloat = 5
+            static let bottom: CGFloat = -5
             static let leading: CGFloat = 10
             static let trailing: CGFloat = -40
         }

--- a/Sources/Views/KMMultiSelectButton.swift
+++ b/Sources/Views/KMMultiSelectButton.swift
@@ -199,7 +199,7 @@ public class KMMultiSelectButton: UIView {
             imageView.heightAnchor.constraint(equalToConstant: 20),
             imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
             label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 5),
-            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 5),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
             label.topAnchor.constraint(equalTo: topAnchor,constant: configuration.topPadding),
             label.bottomAnchor.constraint(equalTo: bottomAnchor,constant: -configuration.bottomPadding),
 


### PR DESCRIPTION
## Summary
- Calling a reloadIfFormMessage(message: lastMessage, indexPath: indexPath). 
- Fixed the button text hiding issue when selected. Reduced the Size by one unit.
- Fixed the button text touching the border issue. Created the padding.

## Images
### Before
<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/6cf6c849-d6af-4f84-820b-cb22c5d64535" alt="before" width="200"> <img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/033acb6f-3beb-4ef5-a997-713921d31214" alt="before" width="200">

### After
<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/1a5ac482-94d7-45ef-bf38-8ca9ba7e3ebc" alt="before" width="200"> <img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/ac572537-62d2-476f-923a-30a8e0d544e9" alt="before" width="200">

