### PR TITLE
[CM-1706] HidePostFormSubmit | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/
 
 ## Unreleased
 - Added hidepostCTA support for all types of buttons.
+- Default configuration added for hiding the form submit button with 'hidePostFormSubmit'.
 
 ## [1.2.0] 2023-10-27
 - Fixed Button Spacing

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -474,6 +474,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     override open func viewDidLoad() {
         super.viewDidLoad()
+        KMHidePostCTAForm.shared.enabledHidePostCTAForm = configuration.hidePostFormSubmit
         self.switchDynamicMode(isDynamic: configuration.isDarkModeEnabled)
         if let templates = viewModel.getMessageTemplates() {
             templateView = ALKTemplateMessagesView(frame: CGRect.zero, viewModel: ALKTemplateMessagesViewModel(messageTemplates: templates))
@@ -2219,6 +2220,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             if message.isSuggestedReply() {
                 tableView.reloadSections([messageIndex], with: .automatic)
             }
+            if message.messageType == .form, KMHidePostCTAForm.shared.enabledHidePostCTAForm {
+                tableView.reloadSections([messageIndex], with: .automatic)
+            }
         }
         moveTableViewToBottom(indexPath: IndexPath(row: 0, section: tableView.numberOfSections - 1))
     }
@@ -2330,6 +2334,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         tableView.insertSections(IndexSet(integer: indexPath.section), with: .automatic)
         tableView.endUpdates()
         if UserDefaults.standard.bool(forKey: SuggestedReplyView.hidePostCTA) {
+            reloadProcessedMessages(index: indexPath.section)
+        }
+        if KMHidePostCTAForm.shared.enabledHidePostCTAForm {
             reloadProcessedMessages(index: indexPath.section)
         }
         moveTableViewToBottom(indexPath: indexPath)

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -88,6 +88,9 @@ public struct ALKConfiguration {
     
     /// if true then dark mode support is enabled to the SDK.
     public var isDarkModeEnabled = false
+    
+    /// For the Form Submit Button, hide post CTA is false by default.
+    public var hidePostFormSubmit = false
 
     /// Status bar style. It will be used in all view controllers.
     /// Default value is lightContent.

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct FormTemplate: Decodable {
-    let elements: [Element]
+    var elements: [Element]
 
     struct Element: Decodable {
         let type: String

--- a/Sources/Utilities/ALKMessageViewModel+Extension.swift
+++ b/Sources/Utilities/ALKMessageViewModel+Extension.swift
@@ -150,7 +150,15 @@ extension ALKMessageViewModel {
     func formTemplate() -> FormTemplate? {
         guard let payload = payloadFromMetadata() else { return nil }
         do {
-            return try FormTemplate(payload: payload)
+            var templet = try FormTemplate(payload: payload)
+                        
+                if isFormSubmitButtonHidden() {
+                    templet.elements.removeAll { element in
+                        return element.type == "submit"
+                    }
+                }
+                        
+            return templet
         } catch {
             print("Error while decoding form template: \(error.localizedDescription)")
             return nil
@@ -189,4 +197,15 @@ extension ALKMessageViewModel {
         }
         return true
     }
+    
+    func isFormSubmitButtonHidden() -> Bool {
+            guard messageType == .form,
+                  KMHidePostCTAForm.shared.enabledHidePostCTAForm,
+                  let currentMessageTime = self.createdAtTime,
+                  let lastSentMessageTime = ALKConversationViewModel.lastSentMessage?.createdAtTime,
+                  currentMessageTime .int64Value < lastSentMessageTime .int64Value else {
+                return false
+            }
+            return true
+        }
 }

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -608,3 +608,8 @@ class FormDataSubmit {
     var dropDownFields = [Int: (Int,String?)]()
     var validationFields = [Int: Int]()
 }
+
+public struct KMHidePostCTAForm {
+    static var shared = KMHidePostCTAForm()
+    var enabledHidePostCTAForm: Bool = false
+}

--- a/Sources/Views/ALKFriendFormCell.swift
+++ b/Sources/Views/ALKFriendFormCell.swift
@@ -114,6 +114,13 @@ class ALKFriendFormCell: ALKFormCell {
             submitButtonView.addSubview(submitButton)
             submitButton.bindFrameToSuperviewBounds()
         }
+        if viewModel.isFormSubmitButtonHidden() {
+            submitButtonView.isHidden = true
+            submitButtonViewHeight.constant = 0
+        } else if KMHidePostCTAForm.shared.enabledHidePostCTAForm, let submitButton = submitButton {
+            submitButtonView.isHidden = false
+            submitButtonViewHeight.constant = submitButton.buttonHeight()
+        }
         timeLabel.setStyle(ALKMessageStyle.time)
         timeLabel.text = viewModel.time
         let timeLabelSize = viewModel.time!.rectWithConstrainedWidth(


### PR DESCRIPTION
## Summary
- Default configuration added for hiding the form submit button with 'hidePostFormSubmit'.

## Video


https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/37ed5d38-c659-4171-aa71-58da72782f16

