### PR TITLE
[CM-1730] Prefill Checkboxes on Form Template for both UI | iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Added support of prefill checkboxes on Form Template.
+
 ## [1.2.1] 2023-11-02
 - Fixed iOS 17 BUtton issue.
 - Fixed the Typing Customization issue.

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2308,6 +2308,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         var formData = FormDataSubmit()
         var index = 0
         for (_, element) in elements.enumerated() {
+            /// We skip indexes for hidden and submit elements in the UI form.
             if element.type == "hidden" || element.type == "submit" {
                 continue
             }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2306,9 +2306,13 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         guard let elements = message.formTemplate()?.elements else { return }
 
         var formData = FormDataSubmit()
-
-        for (elementIndex, element) in elements.enumerated() {
-            processElement(element, at: elementIndex, formData: &formData)
+        var index = 0
+        for (_, element) in elements.enumerated() {
+            if element.type == "hidden" || element.type == "submit" {
+                continue
+            }
+            processElement(element, at: index, formData: &formData)
+            index += 1
         }
 
         ALKFormDataCache.shared.set(formData, for: key)


### PR DESCRIPTION
## Summary
- Added support of pre-fill checkboxes on Form Template.
- Updating ALKFormDataCache before the rendering of Form. That allows to show pre-filled data.

## Working 

1. Just include `"selected": true` in the checkbox options to prefill it.
```
[
    {"label":"Male","value":"male","selected":true},
    {"label":"Female","value":"female"},
    {"label":"Other","value":"other"}
]
```
2. The data of selected Form will be updated only one time in Cache memory at time the form is added first time in message model.
3. When user made Changes in the form new record will be stored in Cache memory.

## Testing

- [x] SPM Testing

## Video 


https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/cb9f0107-4dbf-44a3-9c7c-0fb5c13cbdb4


### SPM Test Video


https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/cd0b5829-a97b-4fff-b2aa-d57131aede80

