### PR TITLE
[CM-1661] Video RM - Youtube embedding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Added Support of Video Rich Message.
+
 ## [1.2.2] 2023-11-15
 - Default configuration added for disabling the form submit button using 'disableFormPostSubmit'.
 - Added support of prefill checkboxes on Form Template.

--- a/Sources/Views/KMFriendVideoTemplateCell.swift
+++ b/Sources/Views/KMFriendVideoTemplateCell.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Kingfisher
 import UIKit
+import RichMessageKit
 
 
 class KMFriendVideoTemplateCell : KMVideoTemplateCell {

--- a/Sources/Views/KMFriendVideoTemplateCell.swift
+++ b/Sources/Views/KMFriendVideoTemplateCell.swift
@@ -8,7 +8,9 @@
 import Foundation
 import Kingfisher
 import UIKit
-
+#if canImport(RichMessageKit)
+    import RichMessageKit
+#endif
 
 class KMFriendVideoTemplateCell : KMVideoTemplateCell {
     let appSettingsUserDefaults = ALKAppSettingsUserDefaults()

--- a/Sources/Views/KMFriendVideoTemplateCell.swift
+++ b/Sources/Views/KMFriendVideoTemplateCell.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Kingfisher
 import UIKit
-import RichMessageKit
 
 
 class KMFriendVideoTemplateCell : KMVideoTemplateCell {

--- a/Sources/Views/KMFriendVideoTemplateCell.swift
+++ b/Sources/Views/KMFriendVideoTemplateCell.swift
@@ -13,6 +13,13 @@ import UIKit
 class KMFriendVideoTemplateCell : KMVideoTemplateCell {
     let appSettingsUserDefaults = ALKAppSettingsUserDefaults()
 
+    fileprivate lazy var messageView = MessageView(
+        bubbleStyle: MessageTheme.receivedMessage.bubble,
+        messageStyle: MessageTheme.receivedMessage.message,
+        maxWidth: ViewPadding.maxWidth - (ViewPadding.messageViewPadding.left + ViewPadding.messageViewPadding.right)
+    )
+
+    lazy var messageViewHeight = self.messageView.heightAnchor.constraint(equalToConstant: 0)
     
     private var avatarImageView: UIImageView = {
         let imv = UIImageView()
@@ -51,26 +58,37 @@ class KMFriendVideoTemplateCell : KMVideoTemplateCell {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(avatarTappedAction))
         avatarImageView.addGestureRecognizer(tapGesture)
 
-        contentView.addViewsForAutolayout(views: [avatarImageView, nameLabel])
+        contentView.addViewsForAutolayout(views: [avatarImageView, messageView, nameLabel])
+        contentView.bringSubviewToFront(messageView)
         nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6).isActive = true
         nameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 57).isActive = true
         nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -56).isActive = true
-        nameLabel.bottomAnchor.constraint(equalTo: videoTableview.topAnchor, constant: -6).isActive = true
+        nameLabel.bottomAnchor.constraint(equalTo: messageView.topAnchor, constant: -6).isActive = true
         nameLabel.heightAnchor.constraint(equalToConstant: 16).isActive = true
 
         avatarImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 18).isActive = true
         avatarImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: 0).isActive = true
 
         avatarImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 9).isActive = true
-        avatarImageView.trailingAnchor.constraint(equalTo: videoTableview.leadingAnchor, constant: -10).isActive = true
+        avatarImageView.trailingAnchor.constraint(equalTo: messageView.leadingAnchor, constant: -10).isActive = true
 
         avatarImageView.heightAnchor.constraint(equalToConstant: 37).isActive = true
         avatarImageView.widthAnchor.constraint(equalTo: avatarImageView.heightAnchor).isActive = true
+        
+        let leftPadding = ChatCellPadding.ReceivedMessage.Message.left
+        let rightPadding = ChatCellPadding.ReceivedMessage.Message.right
+        messageView.topAnchor.constraint(equalTo: nameLabel.bottomAnchor).isActive = true
+        messageView.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: leftPadding).isActive = true
+        messageView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -1 * rightPadding).isActive = true
+        messageViewHeight.isActive = true
 
+        let templateLeftPadding = CGFloat(ALKMessageStyle.receivedBubble.widthPadding)
+
+        videoTableview.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: templateLeftPadding).isActive = true
         videoTableview.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -56).isActive = true
         videoTableview.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16).isActive = true
 
-        videoTableview.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 6).isActive = true
+        videoTableview.topAnchor.constraint(equalTo: messageView.bottomAnchor, constant: 6).isActive = true
         videoTableview.widthAnchor.constraint(equalToConstant: width * 0.60).isActive = true
 
         timeLabel.leadingAnchor.constraint(equalTo: bubbleView.trailingAnchor, constant: 2).isActive = true
@@ -82,7 +100,16 @@ class KMFriendVideoTemplateCell : KMVideoTemplateCell {
     override func update(viewModel: ALKMessageViewModel) {
         super.update(viewModel: viewModel)
         nameLabel.text = viewModel.displayName
-
+        let isMessageEmpty = viewModel.isMessageEmpty
+        let model = viewModel.messageDetails()
+        messageViewHeight.constant = isMessageEmpty ? 0 :
+            ReceivedMessageViewSizeCalculator().rowHeight(messageModel: model, maxWidth: ViewPadding.maxWidth, padding: ViewPadding.messageViewPadding)
+        if !isMessageEmpty {
+            messageView.update(model: model)
+        } else if #available(iOS 17, *) {
+            messageView.update(model: model)
+        }
+        messageView.updateHeighOfView(hideView: isMessageEmpty, model: model)
         let placeHolder = UIImage(named: "placeholder", in: Bundle.km, compatibleWith: nil)
         guard let url = viewModel.avatarURL else {
             avatarImageView.image = placeHolder

--- a/Sources/Views/KMVideoTemplateCell.swift
+++ b/Sources/Views/KMVideoTemplateCell.swift
@@ -163,7 +163,6 @@ extension KMVideoTemplateCell :  UITableViewDataSource, UITableViewDelegate {
         }
         let model = template[indexPath.row]
         let youtubeUrl = "https://www.youtube.com/embed"
-        print("yestysaddsjd : index \(indexPath.row)   url : \(model.url)")
         if model.url.contains(youtubeUrl) {
             let cell: KMYoutubeVideoCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
             cell.updateVideModel(model: model)

--- a/Sources/Views/KMVideoTemplateCell.swift
+++ b/Sources/Views/KMVideoTemplateCell.swift
@@ -25,8 +25,38 @@ class KMVideoTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
     
     private var template: [VideoTemplate]? {
         didSet {
+           videoTableview.reloadData()
            setUpTableView()
         }
+    }
+    
+    enum ViewPadding {
+        enum NameLabel {
+            static let top: CGFloat = 6
+            static let leading: CGFloat = 57
+            static let trailing: CGFloat = 57
+            static let height: CGFloat = 16
+        }
+
+        enum AvatarImageView {
+            static let top: CGFloat = 18
+            static let leading: CGFloat = 9
+            static let height: CGFloat = 37
+            static let width: CGFloat = 37
+        }
+
+        enum TimeLabel {
+            static var leading: CGFloat = 2.0
+            static var top: CGFloat = 2.0
+            static let maxWidth: CGFloat = 200
+        }
+
+        static let maxWidth = UIScreen.main.bounds.width
+            - (ViewPadding.AvatarImageView.width + ViewPadding.AvatarImageView.leading)
+        static let messageViewPadding = Padding(left: ChatCellPadding.ReceivedMessage.Message.left,
+                                                right: ChatCellPadding.ReceivedMessage.Message.right,
+                                                top: ChatCellPadding.ReceivedMessage.Message.top,
+                                                bottom: 0)
     }
 
     var timeLabel: UILabel = {
@@ -74,11 +104,15 @@ class KMVideoTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
         } else {
             heigh = ceil((width * 0.64) / viewModel.ratio)
         }
-        heigh += 50.0
+        let isMessageEmpty = viewModel.isMessageEmpty
+        let messageModel = viewModel.messageDetails()
+        let messagePadding = isMessageEmpty ? 0.0 : ReceivedMessageViewSizeCalculator().rowHeight(messageModel: messageModel, maxWidth: ViewPadding.maxWidth, padding: ViewPadding.messageViewPadding)
+        heigh += ((50.0 + messagePadding) / CGFloat(model.count))
         return heigh * CGFloat(model.count)
     }
 
     override func update(viewModel: ALKMessageViewModel) {
+        super.update(viewModel: viewModel)
         self.messageModel = viewModel
         self.template = viewModel.videoTemplate()
         timeLabel.text = viewModel.time
@@ -114,6 +148,7 @@ class KMVideoTemplateCell: ALKChatBaseCell<ALKMessageViewModel> {
             videoTableview.sectionHeaderTopPadding = 0
         }
         videoTableview.register(KMVideoCell.self)
+        videoTableview.register(KMYoutubeVideoCell.self)
     }
 }
 
@@ -123,14 +158,24 @@ extension KMVideoTemplateCell :  UITableViewDataSource, UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: KMVideoCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
         guard let template = template else {
-            return UITableViewCell() }
-        cell.updateVideModel(model: template[indexPath.row])
-        cell.tapped = { url in
-            self.playtapped?(url)
+            return UITableViewCell()
         }
-        return cell
+        let model = template[indexPath.row]
+        let youtubeUrl = "https://www.youtube.com/embed"
+        print("yestysaddsjd : index \(indexPath.row)   url : \(model.url)")
+        if model.url.contains(youtubeUrl) {
+            let cell: KMYoutubeVideoCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+            cell.updateVideModel(model: model)
+            return cell
+        } else {
+            let cell: KMVideoCell = tableView.dequeueReusableCell(forIndexPath: indexPath)
+            cell.tapped = { url in
+                self.playtapped?(url)
+            }
+            cell.updateVideModel(model: model)
+            return cell
+        }
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/Sources/Views/KMYoutubeVideoCell.swift
+++ b/Sources/Views/KMYoutubeVideoCell.swift
@@ -16,6 +16,10 @@ class KMYoutubeVideoCell: UITableViewCell {
         webView.scrollView.isScrollEnabled = false
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.backgroundColor = .gray
+        webView.layer.borderColor = UIColor.gray.cgColor
+        webView.layer.borderWidth = 1
+        webView.layer.cornerRadius = 5
+        webView.layer.masksToBounds = true
         return webView
     }()
 

--- a/Sources/Views/KMYoutubeVideoCell.swift
+++ b/Sources/Views/KMYoutubeVideoCell.swift
@@ -1,0 +1,68 @@
+//
+//  KMYoutubeVideoCell.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by Abhijeet Ranjan on 22/11/23.
+//
+
+import Foundation
+import UIKit
+import WebKit
+
+class KMYoutubeVideoCell: UITableViewCell {
+
+    var webView: WKWebView = {
+        let webView = WKWebView()
+        webView.scrollView.isScrollEnabled = false
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.backgroundColor = .gray
+        return webView
+    }()
+
+    var captionLabel: UILabel = {
+        let lbl = UILabel()
+        lbl.textColor = .gray
+        lbl.font = UIFont.boldSystemFont(ofSize: 12)
+        return lbl
+    }()
+
+    var viewModel: VideoTemplate?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.isUserInteractionEnabled = true
+        addConstraints()
+        self.backgroundColor = .clear
+    }
+
+    func addConstraints() {
+        addViewsForAutolayout(views: [webView, captionLabel])
+
+        webView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
+        webView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+        webView.topAnchor.constraint(equalTo: topAnchor).isActive = true
+        webView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.width * 0.48).isActive = true
+
+        captionLabel.topAnchor.constraint(equalTo: webView.bottomAnchor).isActive = true
+        captionLabel.centerXAnchor.constraint(equalTo: webView.centerXAnchor).isActive = true
+        captionLabel.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+    }
+
+    func updateVideModel(model: VideoTemplate) {
+        self.viewModel = model
+        captionLabel.text = model.caption ?? ""
+        loadYouTubeVideo(url: model.url)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func loadYouTubeVideo(url: String) {
+        guard let youtubeURL = URL(string: "\(url)?rel=0&showinfo=0&controls=0&modestbranding=1") else {
+            return }
+        
+        let request = URLRequest(url: youtubeURL)
+        webView.load(request)
+    }
+}


### PR DESCRIPTION
## Summary
- Added Support for Youtube Video.
- Added the Message section in Video RM.
- Fixed the height issue coming between Video and timeLable. (when Multiple Video is there)

## Payload
```
{
    "platform": "kommunicate",
    "message": "Hello this is example videos",
    "metadata": {
        "contentType": "300",
        "templateId": "14",
        "payload": [
            {
                "url": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
                "caption": "Video & Youtube Examples"
            },
            {
                "source": "youtube",
                "url": "https://www.youtube.com/embed/3-ijFzzF934",
                "caption": "Video & Youtube Examples"
            }
        ]
    }
}
```

## Testing 
- [x] SPM Testing

## Video

https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/b978c0f7-8606-4c68-8c48-2f409fbfc3f1

### SPM Video

https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/8792691c-a228-4e4a-9f11-bf3ffda6aff2

## Screenshot of height issue

<img width="200" alt="SCR-20230914-qkln" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/97eab42c-d7f7-49da-9228-dab075f91da8"> <img width="200" alt="SCR-20230914-qkln" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/7b57b67d-afe5-4850-b18a-a4678d08b4dc">




