### PR TITLE
[CM-1612] Restrict Agent messaging after 24 hours inactivity for WhatsApp integration

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2178,7 +2178,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         isChatBarResticted = checkRestriceted()
     }
     
-    func checkRestriceted() -> Bool {
+    @objc open func checkRestriceted() -> Bool {
         let channelKey = viewModel.channelKey
         let channelService = ALChannelService()
         let channel = channelService.getChannelByKey(channelKey)
@@ -2196,8 +2196,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
     
     @objc open func twentyFourHoursAgoTimeStamp() -> Double {
         let currentDate = Date()
-        let twentyFourHoursAgo = currentDate.addingTimeInterval(-60)
-            // currentDate.addingTimeInterval(-24 * 60 * 60)
+        let twentyFourHoursAgo = currentDate.addingTimeInterval(-24 * 60 * 60)
         return twentyFourHoursAgo.timeIntervalSince1970 * 1000
     }
 

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -217,6 +217,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             if isChatBarResticted {
                 chatBar.textView.textAlignment = .center
                 chatBar.textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10).isActive = true
+                chatBar.sendButton.isHidden = isChatBarResticted
             } else {
                 chatBar.lineImageView.trailingAnchor.constraint(equalTo: chatBar.sendButton.leadingAnchor, constant: -15).isActive = true
                 chatBar.lineImageView.widthAnchor.constraint(equalToConstant: 2).isActive = true
@@ -232,7 +233,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             }
             chatBar.toggleUserInteractionForViews(enabled: !isChatBarResticted)
             chatBar.textView.isUserInteractionEnabled = !isChatBarResticted
-            chatBar.sendButton.isHidden = isChatBarResticted
             chatBar.updateMediaViewVisibility(hide: isChatBarResticted)
             chatBar.textView.layoutIfNeeded()
         }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2184,7 +2184,7 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         let channel = channelService.getChannelByKey(channelKey)
         let whatsappSource = ["WHATSAPPCLOUDAPI", "WHATSAPPTWILIO", "WHATSAPPDIALOG360"]
         if let platformSource = channel?.platformSource,
-           let lastMessageTime = viewModel.getLastRecivedMessage()?.createdAtTime,
+           let lastMessageTime = viewModel.getLastReceivedMessage()?.createdAtTime,
            Double(truncating: lastMessageTime) <= twentyFourHoursAgoTimeStamp(),
            whatsappSource.contains(platformSource) {
             chatBar.textView.text = "The last message received from this contact was over 24 hours ago. To send Template message, go to the dashboard."

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2184,9 +2184,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         let channel = channelService.getChannelByKey(channelKey)
         let whatsappSource = ["WHATSAPPCLOUDAPI", "WHATSAPPTWILIO", "WHATSAPPDIALOG360"]
         if let platformSource = channel?.platformSource,
+           whatsappSource.contains(platformSource),
            let lastMessageTime = viewModel.getLastReceivedMessage()?.createdAtTime,
-           Double(truncating: lastMessageTime) <= twentyFourHoursAgoTimeStamp(),
-           whatsappSource.contains(platformSource) {
+           Double(truncating: lastMessageTime) <= twentyFourHoursAgoTimeStamp() {
             chatBar.textView.text = "The last message received from this contact was over 24 hours ago. To send Template message, go to the dashboard."
             return true
         } else {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -211,6 +211,32 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             moveTableViewToBottom(indexPath: indexPath)
         }
     }
+    
+    public var isChatBarResticted: Bool = false {
+        didSet {
+            if isChatBarResticted {
+                chatBar.textView.textAlignment = .center
+                chatBar.textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10).isActive = true
+            } else {
+                chatBar.lineImageView.trailingAnchor.constraint(equalTo: chatBar.sendButton.leadingAnchor, constant: -15).isActive = true
+                chatBar.lineImageView.widthAnchor.constraint(equalToConstant: 2).isActive = true
+                chatBar.lineImageView.topAnchor.constraint(equalTo: chatBar.textView.topAnchor, constant: 10).isActive = true
+                chatBar.lineImageView.bottomAnchor.constraint(equalTo: chatBar.textView.bottomAnchor, constant: -10).isActive = true
+
+                chatBar.sendButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10).isActive = true
+                chatBar.sendButton.widthAnchor.constraint(equalToConstant: 28).isActive = true
+                chatBar.sendButton.heightAnchor.constraint(equalToConstant: 28).isActive = true
+                chatBar.sendButton.bottomAnchor.constraint(equalTo: chatBar.textView.bottomAnchor, constant: -7).isActive = true
+                
+                chatBar.textView.trailingAnchor.constraint(equalTo: chatBar.lineImageView.leadingAnchor).isActive = true
+            }
+            chatBar.toggleUserInteractionForViews(enabled: !isChatBarResticted)
+            chatBar.textView.isUserInteractionEnabled = !isChatBarResticted
+            chatBar.sendButton.isHidden = isChatBarResticted
+            chatBar.updateMediaViewVisibility(hide: isChatBarResticted)
+            chatBar.textView.layoutIfNeeded()
+        }
+    }
 
     var contentOffsetDictionary: [AnyHashable: AnyObject]!
 
@@ -2147,6 +2173,33 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
     @objc open func loadingStarted() {
         activityIndicator.startAnimating()
     }
+    
+    @objc open func checkRestrictedMesssaging() {
+        isChatBarResticted = checkRestriceted()
+    }
+    
+    func checkRestriceted() -> Bool {
+        let channelKey = viewModel.channelKey
+        let channelService = ALChannelService()
+        let channel = channelService.getChannelByKey(channelKey)
+        let whatsappSource = ["WHATSAPPCLOUDAPI", "WHATSAPPTWILIO", "WHATSAPPDIALOG360"]
+        if let platformSource = channel?.platformSource,
+           let lastMessageTime = viewModel.getLastRecivedMessage()?.createdAtTime,
+           Double(truncating: lastMessageTime) <= twentyFourHoursAgoTimeStamp(),
+           whatsappSource.contains(platformSource) {
+            chatBar.textView.text = "The last message received from this contact was over 24 hours ago. To send Template message, go to the dashboard."
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    @objc open func twentyFourHoursAgoTimeStamp() -> Double {
+        let currentDate = Date()
+        let twentyFourHoursAgo = currentDate.addingTimeInterval(-60)
+            // currentDate.addingTimeInterval(-24 * 60 * 60)
+        return twentyFourHoursAgo.timeIntervalSince1970 * 1000
+    }
 
     @objc open func loadingFinished(error _: Error?) {
         activityIndicator.stopAnimating()
@@ -2156,6 +2209,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         if newSectionCount > oldSectionCount {
             let offset = newSectionCount - oldSectionCount - 1
             tableView.scrollToRow(at: IndexPath(row: 0, section: offset), at: .none, animated: false)
+        }
+        if ALApplozicSettings.isAgentAppConfigurationEnabled() {
+            isChatBarResticted = checkRestriceted()
         }
         print("loading finished")
         DispatchQueue.main.async {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1431,6 +1431,15 @@ open class ALKConversationViewModel: NSObject, Localizable {
         return nil
     }
     
+    public func getLastRecivedMessage() -> ALMessage? {
+        for message in alMessages.reversed() {
+            if(message.isReceivedMessage()){
+                return message
+            }
+        }
+        return nil
+    }
+    
     func showTypingIndicatorForWelcomeMessage() {
         if welcomeMessagePosition >= alMessages.count {
             return

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1431,7 +1431,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         return nil
     }
     
-    public func getLastRecivedMessage() -> ALMessage? {
+    public func getLastReceivedMessage() -> ALMessage? {
         for message in alMessages.reversed() {
             if(message.isReceivedMessage()){
                 return message

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1433,7 +1433,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
     
     public func getLastReceivedMessage() -> ALMessage? {
         for message in alMessages.reversed() {
-            if(message.isReceivedMessage()){
+            if(message.isReceivedMessage() && message.to != "bot"){
                 return message
             }
         }


### PR DESCRIPTION
## Summary
- Exposed a function to Restrict Agent messaging after 24 hours inactivity for WhatsApp integration.
- Also created a function to get Last Received message.

## Testing
- [x] SPM 
