### PR TITLE
[CM-1778] Add Color Customization for line above input field 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Added Customisation for the line above chatbar.
+
 ## [1.2.3] 2023-12-06
 - Added Support of Video Rich Message.
 - Fixed the attachment upload issue.

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -82,6 +82,9 @@ public struct ALKConfiguration {
 
     /// If true then start new conversation button shown in the empty state will be disabled
     public var hideEmptyStateStartNewButtonInConversationList = false
+    
+    /// Customisation for chatBar for line above input field
+    public var aboveChatbarLineViewColor: UIColor = UIColor.kmDynamicColor(light: UIColor(red: 217.0 / 255.0, green: 217.0 / 255.0, blue: 217.0 / 255.0, alpha: 1.0), dark: UIColor.darkGray)
 
     /// Additional information you can pass in message metadata in all the messages.
     public var messageMetadata: [AnyHashable: Any]?

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -83,8 +83,8 @@ public struct ALKConfiguration {
     /// If true then start new conversation button shown in the empty state will be disabled
     public var hideEmptyStateStartNewButtonInConversationList = false
     
-    /// Customisation for chatBar for line above input field
-    public var aboveChatbarLineViewColor: UIColor = UIColor.kmDynamicColor(light: UIColor(red: 217.0 / 255.0, green: 217.0 / 255.0, blue: 217.0 / 255.0, alpha: 1.0), dark: UIColor.darkGray)
+    /// Customisation for chatBar top line view Color
+    public var chatBarToplineViewColor: UIColor = UIColor.kmDynamicColor(light: UIColor(red: 217.0 / 255.0, green: 217.0 / 255.0, blue: 217.0 / 255.0, alpha: 1.0), dark: UIColor.darkGray)
 
     /// Additional information you can pass in message metadata in all the messages.
     public var messageMetadata: [AnyHashable: Any]?

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -399,7 +399,7 @@ open class ALKChatBar: UIView, Localizable {
         self.configuration = configuration
         isMicButtonHidden = configuration.hideAudioOptionInChatBar
         initializeView()
-        lineView.backgroundColor = configuration.aboveChatbarLineViewColor
+        lineView.backgroundColor = configuration.chatBarToplineViewColor
     }
 
     deinit {

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -217,7 +217,6 @@ open class ALKChatBar: UIView, Localizable {
     open var lineView: UIView = {
         let view = UIView()
         let layer = view.layer
-        view.backgroundColor = UIColor.kmDynamicColor(light: UIColor(red: 217.0 / 255.0, green: 217.0 / 255.0, blue: 217.0 / 255.0, alpha: 1.0), dark: UIColor.darkGray)
         return view
     }()
 
@@ -400,6 +399,7 @@ open class ALKChatBar: UIView, Localizable {
         self.configuration = configuration
         isMicButtonHidden = configuration.hideAudioOptionInChatBar
         initializeView()
+        lineView.backgroundColor = configuration.aboveChatbarLineViewColor
     }
 
     deinit {


### PR DESCRIPTION
## Summary
- Added Customisation for the line above chatbar.

## Verified
- [x] SPM

## Image with code 
```
Kommunicate.defaultConfiguration.chatBarToplineViewColor = UIColor.red
```

<img width="200" alt="SCR-20230914-qkln" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/89996d75-9f75-43df-8c87-6c3cee1b367a">