### PR TITLE
[CM-1670] Getting blue while sending location

### DIFF
--- a/Sources/Views/ALKLocationCell.swift
+++ b/Sources/Views/ALKLocationCell.swift
@@ -122,8 +122,12 @@ class ALKLocationCell: ALKChatBaseCell<ALKMessageViewModel>,
         timeLabel.text = viewModel.time
 
         // addressLabel
-        if let geocode = viewModel.geocode {
+        if let geocode = viewModel.geocode, geocode.formattedAddress != "" {
             addressLabel.text = geocode.formattedAddress
+        } else {
+            addressLabel.isHidden = true 
+            locationImageView.bottomAnchor.constraint(equalTo: bubbleView.bottomAnchor, constant: 0.0).isActive = true
+            layoutIfNeeded()
         }
 
         // locationImageView


### PR DESCRIPTION
## Summary
- fixed the addressLable coming when there is no geocode.formattedAddress available in viewModel.

## Image ( Before : After ) 

<img width="200" alt="SCR-20230914-qkln" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/96951ebd-7bc8-4f48-832d-03f57c4dc25e"> <img width="200" alt="SCR-20230914-qkln" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/974db652-9875-4752-81fa-def1bbbf7977"> 


