### PR TITLE
[CM-1759] Quick Reply implementation for TaxBuddy

### DIFF
--- a/Sources/Controllers/ALKConversationViewController+AutoComplete.swift
+++ b/Sources/Controllers/ALKConversationViewController+AutoComplete.swift
@@ -9,9 +9,7 @@ import Foundation
 import UIKit
 
 extension ALKConversationViewController: AutoCompletionDelegate {
-    public func sendMessage(content: String) {
-        
-    }
+    public func sendMessage(content: String) {}
     
     public func didMatch(prefix: String, message: String, updated: Bool) {
         if isAutoSuggestionRichMessage , message.count >= 2 {
@@ -25,7 +23,7 @@ extension ALKConversationViewController: AutoCompletionDelegate {
                     let items = suggestionDict
                     for dictionary in items {
                         if let key = dictionary["searchKey"] as? String, let content = dictionary["message"] as? String {
-                            let autoCompleteItem = AutoCompleteItem(key: key, content: content, supportsRichMessage: nil)
+                            let autoCompleteItem = AutoCompleteItem(key: key, content: content)
                             arrayOfAutocomplete.append(autoCompleteItem)
                         }
                     }
@@ -34,14 +32,14 @@ extension ALKConversationViewController: AutoCompletionDelegate {
                     let items = suggestionDict
                     for dictionary in items {
                         if let key = dictionary["searchKey" ] as? String, let content = dictionary["message"] as? String{
-                            let autoCompleteItem = AutoCompleteItem(key: key, content: content, supportsRichMessage: nil)
+                            let autoCompleteItem = AutoCompleteItem(key: key, content: content)
                             arrayOfAutocomplete.append(autoCompleteItem)
                         }
                     }
                 }
             } else {
                 let items = suggestionArray
-                arrayOfAutocomplete = items.map{ AutoCompleteItem(key: $0, content: $0, supportsRichMessage: nil)}
+                arrayOfAutocomplete = items.map{ AutoCompleteItem(key: $0, content: $0)}
             }
             if message.isEmpty {
                 autoSuggestionManager.items = arrayOfAutocomplete

--- a/Sources/Controllers/ALKConversationViewController+AutoComplete.swift
+++ b/Sources/Controllers/ALKConversationViewController+AutoComplete.swift
@@ -9,6 +9,10 @@ import Foundation
 import UIKit
 
 extension ALKConversationViewController: AutoCompletionDelegate {
+    public func sendMessage(content: String) {
+        
+    }
+    
     public func didMatch(prefix: String, message: String, updated: Bool) {
         if isAutoSuggestionRichMessage , message.count >= 2 {
             var arrayOfAutocomplete: [AutoCompleteItem] = []
@@ -21,7 +25,7 @@ extension ALKConversationViewController: AutoCompletionDelegate {
                     let items = suggestionDict
                     for dictionary in items {
                         if let key = dictionary["searchKey"] as? String, let content = dictionary["message"] as? String {
-                            let autoCompleteItem = AutoCompleteItem(key: key, content: content)
+                            let autoCompleteItem = AutoCompleteItem(key: key, content: content, supportsRichMessage: nil)
                             arrayOfAutocomplete.append(autoCompleteItem)
                         }
                     }
@@ -30,14 +34,14 @@ extension ALKConversationViewController: AutoCompletionDelegate {
                     let items = suggestionDict
                     for dictionary in items {
                         if let key = dictionary["searchKey" ] as? String, let content = dictionary["message"] as? String{
-                            let autoCompleteItem = AutoCompleteItem(key: key, content: content)
+                            let autoCompleteItem = AutoCompleteItem(key: key, content: content, supportsRichMessage: nil)
                             arrayOfAutocomplete.append(autoCompleteItem)
                         }
                     }
                 }
             } else {
                 let items = suggestionArray
-                arrayOfAutocomplete = items.map{ AutoCompleteItem(key: $0, content: $0)}
+                arrayOfAutocomplete = items.map{ AutoCompleteItem(key: $0, content: $0, supportsRichMessage: nil)}
             }
             if message.isEmpty {
                 autoSuggestionManager.items = arrayOfAutocomplete

--- a/Sources/Controllers/AutoCompleteManager.swift
+++ b/Sources/Controllers/AutoCompleteManager.swift
@@ -12,6 +12,7 @@ import UIKit
 
 public protocol AutoCompletionDelegate: AnyObject {
     func didMatch(prefix: String, message: String, updated: Bool)
+    func sendMessage(content : String)
 }
 
 public protocol AutoCompletionItemCell: UITableViewCell {
@@ -108,6 +109,14 @@ public class AutoCompleteManager: NSObject {
     }
 
     func insert(item: AutoCompleteItem, at insertionRange: NSRange, replace selection: Selection) {
+        
+        if let supportsRichMessage = item.supportsRichMessage,
+           supportsRichMessage {
+            self.autocompletionDelegate?.sendMessage(content: item.content)
+            textView.text = ""
+            return
+        }
+        
         let defaultAttributes = textView.typingAttributes
         var newAttributes = defaultAttributes
         let configuration = prefixConfigurations[selection.prefix] ?? AutoCompleteItemConfiguration()

--- a/Sources/Models/AutoCompleteItem.swift
+++ b/Sources/Models/AutoCompleteItem.swift
@@ -11,11 +11,13 @@ public struct AutoCompleteItem {
     public let key: String
     public let content: String
     public let displayImageURL: URL?
+    public let supportsRichMessage: Bool?
 
-    public init(key: String, content: String, displayImageURL: URL? = nil) {
+    public init(key: String, content: String, displayImageURL: URL? = nil, supportsRichMessage : Bool?) {
         self.key = key
         self.content = content
         self.displayImageURL = displayImageURL
+        self.supportsRichMessage = supportsRichMessage
     }
 }
 

--- a/Sources/Models/AutoCompleteItem.swift
+++ b/Sources/Models/AutoCompleteItem.swift
@@ -13,7 +13,7 @@ public struct AutoCompleteItem {
     public let displayImageURL: URL?
     public let supportsRichMessage: Bool?
 
-    public init(key: String, content: String, displayImageURL: URL? = nil, supportsRichMessage : Bool?) {
+    public init(key: String, content: String, displayImageURL: URL? = nil, supportsRichMessage : Bool? = nil) {
         self.key = key
         self.content = content
         self.displayImageURL = displayImageURL

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1718,7 +1718,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         let items =
             members
                 .filter { $0.userId != ALUserDefaultsHandler.getUserId() }
-                .map { AutoCompleteItem(key: $0.userId, content: $0.displayName ?? $0.userId, displayImageURL: $0.friendDisplayImgURL, supportsRichMessage: nil) }
+                .map { AutoCompleteItem(key: $0.userId, content: $0.displayName ?? $0.userId, displayImageURL: $0.friendDisplayImgURL) }
                 .sorted { $0.content < $1.content }
         return items
     }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1718,7 +1718,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         let items =
             members
                 .filter { $0.userId != ALUserDefaultsHandler.getUserId() }
-                .map { AutoCompleteItem(key: $0.userId, content: $0.displayName ?? $0.userId, displayImageURL: $0.friendDisplayImgURL) }
+                .map { AutoCompleteItem(key: $0.userId, content: $0.displayName ?? $0.userId, displayImageURL: $0.friendDisplayImgURL, supportsRichMessage: nil) }
                 .sorted { $0.content < $1.content }
         return items
     }


### PR DESCRIPTION
### Overview
Taxbuddy wanted to reassign a conversation back to a bot by using quick replies provided in the dashboard.
We have modified the quickreplies for the same. 
The idea is that they will identify the event at universal webhook and trigger reassignment.

### What do you want to achieve?
- Provide a way to send specific events along with the quickreplies.

## Verified
- [x] SPM

## Video


https://github.com/Kommunicate-io/Kommunicate-iOS-AgentApp/assets/139108613/34869634-833c-445a-93ae-3eb82f819844