### PR TITLE
[CM-1614] Thumbnail for the videos is not showing after reopening the conversation

### DIFF
--- a/Sources/Views/ALKVideoCell.swift
+++ b/Sources/Views/ALKVideoCell.swift
@@ -265,12 +265,16 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
             playButton.isHidden = true
             progressView.isHidden = true
             loadThumbnail()
-        case .downloaded:
+        case let .downloaded(filePath):
             uploadButton.isHidden = true
             downloadButton.isHidden = true
             progressView.isHidden = true
             playButton.isHidden = false
             loadThumbnail()
+            let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            let path = docDirPath.appendingPathComponent(filePath)
+            let fileUtills = ALKFileUtils()
+            photoView.image = fileUtills.getThumbnail(filePath: path)
         case let .downloading(progress, _):
             // show progress bar
             print("downloading")


### PR DESCRIPTION
## Summary
- fixed the Thumbnail for the videos is not showing after reopening.

## Video (Before : After)

https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/aeb4a523-4469-41bd-b84f-008eabcb33b9



https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/5e83a789-25c5-45ca-ae7e-f658b2a26444

