### PR TITLE
[CM-1792] Fixed link preview showing for deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## Unreleased
+- Fixed link preview showing for deep link
 
 ## [1.2.5] 2023-12-23
 - Restrict agent reply for zendesk conversation

--- a/Sources/LinkPreview/ALKLinkPreviewManager.swift
+++ b/Sources/LinkPreview/ALKLinkPreviewManager.swift
@@ -211,12 +211,19 @@ class ALKLinkPreviewManager: NSObject, URLSessionDelegate {
                 let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
                 let range = NSRange(location: 0, length: message.utf16.count)
                 let matches = detector.matches(in: message, options: [], range: range)
-                let url = matches.compactMap { $0.url }.first
+                
+                let validURLs = matches.compactMap { result -> URL? in
+                    guard result.resultType == .link, let url = result.url, url.scheme?.lowercased().starts(with: "http") == true else {
+                        return nil
+                    }
+                    return url
+                }
 
-                guard let urlString = url?.absoluteString, !urlString.starts(with: "mailto:") else {
+                guard let url = validURLs.first else {
                     return nil
                 }
-                urlCache.setObject(urlString as NSString, forKey: identifier as NSString)
+
+                urlCache.setObject(url.absoluteString as NSString, forKey: identifier as NSString)
                 return url
             } catch {
                 return nil

--- a/Sources/Views/ALKLinkPreviewBaseCell.swift
+++ b/Sources/Views/ALKLinkPreviewBaseCell.swift
@@ -15,6 +15,7 @@ class ALKLinkPreviewBaseCell: ALKMessageCell {
         super.update(viewModel: viewModel, messageStyle: messageStyle, mentionStyle: mentionStyle)
         linkView.setLocalizedStringFileName(localizedStringFileName)
         url = ALKLinkPreviewManager.extractURLAndAddInCache(from: viewModel.message, identifier: viewModel.identifier)?.absoluteString
+        linkView.previewImageView.image = UIImage(named: "default_image", in: Bundle.km, compatibleWith: nil)
     }
 
     override func setupViews() {


### PR DESCRIPTION
## Summary

Previously deep link were having previews which should ideally not happen. Now ,only the hyperlinks will have preview option

## Testing

- Add a url scheme to enable deeplinks inside `Project Settings -> Info -> URL Types`
- Send a message with that deeplink like urlScheme:.//menu
- Verify that there is no link preview for that message

## Verified

- [X] SPM