### PR TITLE
[CM-1828] Expose customisation for Docx and Zips in ALKDocumentManager

### DIFF
--- a/Sources/Controllers/ALKDocumentManager.swift
+++ b/Sources/Controllers/ALKDocumentManager.swift
@@ -16,14 +16,7 @@ class ALKDocumentManager: NSObject {
     weak var delegate: ALKDocumentManagerDelegate?
 
     func showPicker(from controller: UIViewController) {
-        let types = [
-            kUTTypeText as String,
-            kUTTypePresentation as String,
-            kUTTypeSpreadsheet as String,
-            kUTTypePDF as String,
-            "com.microsoft.word.doc",
-            "com.microsoft.excel.xls",
-        ]
+        let types = KMDocumentConfiguration.shared.getDocumentOptions()
         let importMenu = UIDocumentPickerViewController(documentTypes: types, in: .import)
         importMenu.delegate = self
         importMenu.modalPresentationStyle = .formSheet

--- a/Sources/Models/KMDocumentConfiguration.swift
+++ b/Sources/Models/KMDocumentConfiguration.swift
@@ -1,0 +1,59 @@
+//
+//  KMDocumentConfiguration.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by Abhijeet Ranjan on 08/01/24.
+//
+
+import Foundation
+import MobileCoreServices
+
+public enum DocumentType: CaseIterable, Equatable {
+    case pdf
+    case excel
+    case docs
+    case docx
+    case presentation
+    case word
+    case spreadsheet
+}
+
+public struct KMDocumentConfiguration {
+    
+    public static var shared =  KMDocumentConfiguration()
+    
+    public var documentOptions: DocumentOptions = .some([.docs,.excel,.pdf,.presentation,.spreadsheet,.word])
+    
+    public enum DocumentOptions {
+        case all
+        case some([DocumentType])
+    }
+    
+    public mutating func setDocumentOptions(_ options: DocumentOptions) {
+        documentOptions = options
+    }
+    
+    public func getDocumentOptions() -> [String] {
+        switch documentOptions {
+        case .all:
+            return ["public.data"]
+        case .some(let selectedTypes):
+            return selectedTypes.map { documentType in
+                mapDocumentTypeToUTType(documentType)
+            }
+        }
+    }
+    
+    private func mapDocumentTypeToUTType(_ documentType: DocumentType) -> String {
+        switch documentType {
+        case .pdf: return kUTTypePDF as String
+        case .excel: return "com.microsoft.excel.xls"
+        case .docs: return kUTTypeText as String
+        case .docx: return "org.openxmlformats.wordprocessingml.document"
+        case .presentation: return kUTTypePresentation as String
+        case .word: return "com.microsoft.word.doc"
+        case .spreadsheet: return kUTTypeSpreadsheet as String
+        }
+    }
+}
+

--- a/Sources/Models/KMDocumentConfiguration.swift
+++ b/Sources/Models/KMDocumentConfiguration.swift
@@ -10,11 +10,11 @@ import MobileCoreServices
 
 public enum DocumentType: CaseIterable, Equatable {
     case pdf
-    case excel
-    case docs
+    case xls
+    case text
     case docx
     case presentation
-    case word
+    case doc
     case spreadsheet
 }
 
@@ -22,7 +22,7 @@ public struct KMDocumentConfiguration {
     
     public static var shared =  KMDocumentConfiguration()
     
-    public var documentOptions: DocumentOptions = .some([.docs,.excel,.pdf,.presentation,.spreadsheet,.word])
+    public var documentOptions: DocumentOptions = .some([.text,.xls,.pdf,.presentation,.spreadsheet,.doc])
     
     public enum DocumentOptions {
         case all
@@ -47,11 +47,11 @@ public struct KMDocumentConfiguration {
     private func mapDocumentTypeToUTType(_ documentType: DocumentType) -> String {
         switch documentType {
         case .pdf: return kUTTypePDF as String
-        case .excel: return "com.microsoft.excel.xls"
-        case .docs: return kUTTypeText as String
+        case .xls: return "com.microsoft.excel.xls"
+        case .text: return kUTTypeText as String
         case .docx: return "org.openxmlformats.wordprocessingml.document"
         case .presentation: return kUTTypePresentation as String
-        case .word: return "com.microsoft.word.doc"
+        case .doc: return "com.microsoft.word.doc"
         case .spreadsheet: return kUTTypeSpreadsheet as String
         }
     }


### PR DESCRIPTION
## Summary
- Added customisation for Document manager files to be visible to upload.

## Code
Note :  Need to `import KommunicateChatUI_iOS_SDK`
- For Customisation 
```
KMDocumentConfiguration.shared.setDocumentOptions(KMDocumentConfiguration.DocumentOptions.some([.docs,.excel, .pdf, .presentation]))
```
- For enabling All
```
KMDocumentConfiguration.shared.setDocumentOptions(KMDocumentConfiguration.DocumentOptions.all)
```

## SPM 
- [x] Verified

