### PR TITLE
[CM-1829] AWS Encrypted titled docs while uploading | iOS SDK

### DIFF
--- a/Sources/Utilities/ALKFileUtils.swift
+++ b/Sources/Utilities/ALKFileUtils.swift
@@ -17,7 +17,7 @@ class ALKFileUtils: NSObject {
             }
             return (localPathName as NSString).lastPathComponent as String
         }
-        return fileName
+        return fileName.replace("AWS-ENCRYPTED-", with: "")
     }
 
     func getFileSize(filePath: String?, fileMetaInfo: ALFileMetaInfo?) -> String? {


### PR DESCRIPTION
## Summary
- Removed AWS-ENCRYPTED- from the file name.

