### PR TITLE
[CM-1743] [NSException initWithCoder:]

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2358,12 +2358,6 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             return
         }
         tableView.scrollToRow(at: indexPath, at: .bottom, animated: false)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            let sectionCount = self.tableView.numberOfSections
-            if indexPath.section <= sectionCount {
-                self.tableView.scrollToRow(at: indexPath, at: .bottom, animated: false)
-            }
-        }
     }
     
     public func updateChatbarText(text: String) {


### PR DESCRIPTION
## Summary
- Removed the extra call of `tableView.scrollToRow(at: indexPath, at: .bottom, animated: false)`
- Potential reason of crash as per stack trace received.