### PR TITLE
[CM-1722] Added support of Form data using Dialogflow fulfillment Form 

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1791,6 +1791,11 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                let hiddenValue = elementData.value
             {
                 postFormData[hiddenName] = hiddenValue
+            } else if element.contentType == .hidden,
+                      let hiddenName = element.name,
+                      let hiddenValue = element.value
+            {
+                postFormData[hiddenName] = hiddenValue
             }
 
             if element.contentType == .submit,
@@ -1812,6 +1817,26 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 }
                 
                 if let metadata = action.metadata  {
+                    actionMessageMetaData = metadata
+                }
+            }
+            
+            if element.contentType == .submit, element.data == nil {
+                
+                if let formTemplateRequest = element.requestType {
+                    requestType = formTemplateRequest
+                }
+                if let formTemplateAction = element.formAction {
+                    formAction = formTemplateAction
+                }
+                if let formTemplateMessage = element.message {
+                    message = formTemplateMessage
+                }
+                if let formTemplatePostFormDataAsMessage = element.postBackToKommunicate, formTemplatePostFormDataAsMessage {
+                    isFormDataReplytoChat = true
+                }
+                
+                if let metadata = element.metadata  {
                     actionMessageMetaData = metadata
                 }
             }
@@ -2407,15 +2432,25 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
 
     func processElement(_ element: FormTemplate.Element, at elementIndex: Int, formData: inout FormDataSubmit) {
         let elementType = element.type
-        guard let details = element.data, let options = details.options else { return }
-
-        switch elementType {
-        case "radio":
-            processRadioElement(options, at: elementIndex, formData: &formData)
-        case "checkbox":
-            processCheckboxElement(options, at: elementIndex, formData: &formData)
-        default:
-            break
+        
+        if let details = element.data, let options = details.options {
+            switch elementType {
+            case "radio":
+                processRadioElement(options, at: elementIndex, formData: &formData)
+            case "checkbox":
+                processCheckboxElement(options, at: elementIndex, formData: &formData)
+            default:
+                break
+            }
+        } else if let options = element.options {
+            switch elementType {
+            case "radio":
+                processRadioElement(options, at: elementIndex, formData: &formData)
+            case "checkbox":
+                processCheckboxElement(options, at: elementIndex, formData: &formData)
+            default:
+                break
+            }
         }
     }
 

--- a/Sources/Models/FormTemplate.swift
+++ b/Sources/Models/FormTemplate.swift
@@ -13,6 +13,11 @@ struct FormTemplate: Decodable {
     struct Element: Decodable {
         let type: String
         let data: Details?
+        let options: [Option]?
+        let title, name, label, value, placeholder: String?
+        let formAction, message, requestType, postFormDataAsMessage: String?
+        var postBackToKommunicate: Bool?
+        var metadata : [String:String]?
     }
 
     struct Details: Decodable {

--- a/Sources/ViewModels/ALKFormViewModelItem.swift
+++ b/Sources/ViewModels/ALKFormViewModelItem.swift
@@ -235,13 +235,20 @@ extension FormTemplate {
                                                            title: title,
                                                            options: options))
             case .multiselect:
-                guard let elementData = element.data,
-                      let title = elementData.title,
-                      let options = elementData.options,
-                      let name = elementData.name else { return }
-                items.append(FormViewModelMultiselectItem(name: name,
-                                                          title: title,
-                                                          options: options))
+                if let elementData = element.data,
+                   let title = elementData.title,
+                   let options = elementData.options,
+                   let name = elementData.name {
+                    items.append(FormViewModelMultiselectItem(name: name,
+                                                              title: title,
+                                                              options: options))
+                } else if let title = element.title,
+                          let options = element.options,
+                          let name = element.name {
+                    items.append(FormViewModelMultiselectItem(name: name,
+                                                              title: title,
+                                                              options: options))
+                } else { return }
             case .time:
                 guard let elementData = element.data,
                       let label = elementData.label else { return }
@@ -268,10 +275,17 @@ extension FormTemplate {
     }
 
     var submitButtonTitle: String? {
-        guard let submitButton = elements
+        if let submitButton = elements
             .filter({ $0.contentType == .submit })
             .first, let submitButtonData = submitButton.data,
-            let buttonName = submitButtonData.name else { return nil }
-        return buttonName
+           let buttonName = submitButtonData.name {
+            return buttonName
+        } else if let submitButton = elements
+            .filter({ $0.contentType == .submit })
+            .first, let buttonName = submitButton.label {
+            return buttonName
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Added support of Dialog Flow CheckBox Form.

## Payload
- https://docs.kommunicate.io/docs/message-types#form-data-using-dialogflow-fulfillment

## Verified 
- [x] Other Check Box Form 
- [x] SPM

## Video

https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/6326a732-9c4f-4c8b-a0c8-6437b0845adf

