### PR TITLE
[CM-1853] Assign To message UI Match, Message text

### DIFF
--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -174,6 +174,9 @@ AddGroupDescriptionPlaceHolder = "Add group description";
 /* Feedback */
  RatingLabelTitle = "You";
 
+/* Assigned To */
+ AssignedLabel = "Conversation transferred to";
+
 /* Delete Conversation */
 DeleteConversationTitle = "Delete Conversation";
 DeleteConversationContent = "Do you want to delete the conversation?";

--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -59,6 +59,13 @@ public enum ALKMessageStyle {
         background: UIColor.gray
     )
     
+    /// Style for Assignment Message in chat
+    public static var assignmentMessage = Style(
+        font: UIFont.font(.normal(size: 12)),
+        text: UIColor.gray,
+        background: UIColor.gray
+    )
+    
     /// Style for channel info messages in chat
     public static var infoMessage = Style(
         font: UIFont.font(.bold(size: 12.0)),

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -230,6 +230,10 @@ struct SystemMessage: Localizable {
         static let RatingLabelTitle = localizedString(forKey: "RatingLabelTitle")
     }
     
+    enum AssignedInfo {
+        static let AssignedLabel = localizedString(forKey: "AssignedLabel")
+    }
+    
     enum DeleteConversationPopup {
         static let title = localizedString(forKey: "DeleteConversationTitle")
         static let content = localizedString(forKey: "DeleteConversationContent")

--- a/Sources/Views/ALKInformationCell.swift
+++ b/Sources/Views/ALKInformationCell.swift
@@ -57,6 +57,17 @@ final class ALKInformationCell: UITableViewCell, Localizable {
         return tv
     }()
     
+    fileprivate var assignTextView: UITextView = {
+        let tv = UITextView()
+        tv.isEditable = false
+        tv.backgroundColor = .clear
+        tv.isSelectable = false
+        tv.isScrollEnabled = false
+        tv.isUserInteractionEnabled = false
+        tv.textAlignment = .center
+        return tv
+    }()
+    
     fileprivate var bubbleView: UIView = {
         let bv = UIView()
         bv.backgroundColor = UIColor.clear
@@ -140,7 +151,9 @@ final class ALKInformationCell: UITableViewCell, Localizable {
             if !ALApplozicSettings.isAgentAppConfigurationEnabled() {
                 let assignmentTitle = localizedString(forKey: "AssignedLabel", withDefaultValue: SystemMessage.AssignedInfo.AssignedLabel, fileName: configuration.localizedStringFileName)
                 let message = viewModel.message?.replacingOccurrences(of: "Assigned to", with: assignmentTitle, options: .literal, range: nil)
-                messageView.text = message
+                assignTextView.text = message
+                bubbleView.isHidden = true
+                messageView.text = ""
                 commentTextView.text = ""
                 setupConstraintsForAssignedTo()
             } else {
@@ -230,14 +243,14 @@ final class ALKInformationCell: UITableViewCell, Localizable {
         lineViewRight.isHidden = false
         horizontalStackView.spacing = Padding.HorizontalStackView.spacing
         horizontalStackView.addArrangedSubview(lineViewLeft)
-        horizontalStackView.addArrangedSubview(messageView)
+        horizontalStackView.addArrangedSubview(assignTextView)
         horizontalStackView.addArrangedSubview(lineViewRight)
       
         lineViewLeft.backgroundColor = .lightGray
         lineViewRight.backgroundColor = .lightGray
         
         contentView.addViewsForAutolayout(views: [horizontalStackView])
-        contentView.bringSubviewToFront(messageView)
+        contentView.bringSubviewToFront(assignTextView)
         
         horizontalStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Padding.HorizontalStackView.leading).isActive = true
         horizontalStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Padding.HorizontalStackView.trailing).isActive = true
@@ -247,7 +260,8 @@ final class ALKInformationCell: UITableViewCell, Localizable {
         lineViewLeft.heightAnchor.constraint(equalToConstant: Padding.LineView.height).isActive = true
         lineViewRight.heightAnchor.constraint(equalToConstant: Padding.LineView.height).isActive = true
         
-        messageView.setFont(ALKMessageStyle.infoMessage.font)
+        assignTextView.setFont(ALKMessageStyle.assignmentMessage.font)
+        assignTextView.setTextColor(ALKMessageStyle.assignmentMessage.text)
         contentView.backgroundColor = UIColor.clear
         backgroundColor = UIColor.clear
     }

--- a/Sources/Views/ALKInformationCell.swift
+++ b/Sources/Views/ALKInformationCell.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import KommunicateCore_iOS_SDK
 
 final class ALKInformationCell: UITableViewCell, Localizable {
     var configuration = ALKConfiguration()
@@ -80,13 +81,11 @@ final class ALKInformationCell: UITableViewCell, Localizable {
     
     fileprivate var lineViewLeft : UIView = {
         let view = UIView()
-        view.isHidden = true
         return view
     }()
     
     fileprivate var lineViewRight : UIView = {
         let view = UIView()
-        view.isHidden = true
         return view
     }()
 
@@ -138,11 +137,19 @@ final class ALKInformationCell: UITableViewCell, Localizable {
     func update(viewModel: ALKMessageViewModel) {
         self.viewModel = viewModel
         guard let feedback = getFeedback(viewModel: viewModel) else {
-            messageView.text = viewModel.message
-            commentTextView.text = ""
-            lineViewLeft.isHidden = true
-            lineViewRight.isHidden = true
-            setupConstraints()
+            if !ALApplozicSettings.isAgentAppConfigurationEnabled() {
+                let assignmentTitle = localizedString(forKey: "AssignedLabel", withDefaultValue: SystemMessage.AssignedInfo.AssignedLabel, fileName: configuration.localizedStringFileName)
+                let message = viewModel.message?.replacingOccurrences(of: "Assigned to", with: assignmentTitle, options: .literal, range: nil)
+                messageView.text = message
+                commentTextView.text = ""
+                setupConstraintsForAssignedTo()
+            } else {
+                messageView.text = viewModel.message
+                commentTextView.text = ""
+                lineViewLeft.isHidden = true
+                lineViewRight.isHidden = true
+                setupConstraints()
+            }
             return
         }
         
@@ -208,6 +215,38 @@ final class ALKInformationCell: UITableViewCell, Localizable {
         bubbleView.rightAnchor.constraint(equalTo: messageView.rightAnchor, constant: 4).isActive = true
         
         bubbleView.backgroundColor = ALKMessageStyle.infoMessage.background
+        messageView.setFont(ALKMessageStyle.infoMessage.font)
+        contentView.backgroundColor = UIColor.clear
+        backgroundColor = UIColor.clear
+    }
+    
+    fileprivate func setupConstraintsForAssignedTo() {
+        let horizontalStackView = UIStackView()
+        
+        horizontalStackView.axis  = NSLayoutConstraint.Axis.horizontal
+        horizontalStackView.distribution  = UIStackView.Distribution.equalSpacing
+        horizontalStackView.alignment = UIStackView.Alignment.center
+        lineViewLeft.isHidden = false
+        lineViewRight.isHidden = false
+        horizontalStackView.spacing = Padding.HorizontalStackView.spacing
+        horizontalStackView.addArrangedSubview(lineViewLeft)
+        horizontalStackView.addArrangedSubview(messageView)
+        horizontalStackView.addArrangedSubview(lineViewRight)
+      
+        lineViewLeft.backgroundColor = .lightGray
+        lineViewRight.backgroundColor = .lightGray
+        
+        contentView.addViewsForAutolayout(views: [horizontalStackView])
+        contentView.bringSubviewToFront(messageView)
+        
+        horizontalStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Padding.HorizontalStackView.leading).isActive = true
+        horizontalStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: Padding.HorizontalStackView.trailing).isActive = true
+        
+        lineViewLeft.widthAnchor.constraint(equalToConstant: Padding.LineView.width).isActive = true
+        lineViewRight.widthAnchor.constraint(equalToConstant: Padding.LineView.width).isActive = true
+        lineViewLeft.heightAnchor.constraint(equalToConstant: Padding.LineView.height).isActive = true
+        lineViewRight.heightAnchor.constraint(equalToConstant: Padding.LineView.height).isActive = true
+        
         messageView.setFont(ALKMessageStyle.infoMessage.font)
         contentView.backgroundColor = UIColor.clear
         backgroundColor = UIColor.clear


### PR DESCRIPTION
## Summary
- Added the new UI to Assigned to Message
- Added localised String for assign to label.
- Added Support of customisation in Assignment Message.

## Verified 
- [x] SPM

## Images
<img width="200" alt="SCR-20230914-qkln" src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/65e3a708-cb37-4eca-8de2-17ea6eb0b488">


