### PR TITLE
[CM-1834] Link preview for 2nd last message is being overridden by last msg

### DIFF
--- a/Sources/LinkPreview/ALKLinkPreviewManager.swift
+++ b/Sources/LinkPreview/ALKLinkPreviewManager.swift
@@ -17,7 +17,7 @@ class ALKLinkPreviewManager: NSObject, URLSessionDelegate {
         self.responseMainQueue = responseMainQueue
     }
 
-    func makePreview(from text: String, identifier: String, _ completion: @escaping (Result<LinkPreviewMeta, LinkPreviewFailure>) -> Void) {
+    func makePreview(from text: String, identifier: String, _ completion: @escaping (Result<(LinkPreviewMeta, URL), LinkPreviewFailure>) -> Void) {
         guard let url = ALKLinkPreviewManager.extractURLAndAddInCache(from: text, identifier: identifier) else {
             responseMainQueue.async {
                 completion(.failure(.noURLFound))
@@ -66,7 +66,7 @@ class ALKLinkPreviewManager: NSObject, URLSessionDelegate {
                 }
                 LinkURLCache.addLink(linkPreviewData, for: linkPreviewData.url.absoluteString)
                 weakSelf.responseMainQueue.async {
-                    completion(.success(linkPreviewData))
+                    completion(.success((linkPreviewData, url)))
                 }
 
             }.resume()

--- a/Sources/Views/ALKLinkView.swift
+++ b/Sources/Views/ALKLinkView.swift
@@ -70,9 +70,19 @@ class ALKLinkView: UIView, Localizable {
         return imageView
     }()
 
+    private var currentURL: String?
+    private var currentIdentifier: String?
+
     init() {
         super.init(frame: .zero)
         setupConstraintAndView()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if let url = currentURL, let identifier = currentIdentifier {
+            update(url: url, identifier: identifier)
+        }
     }
 
     @available(*, unavailable)
@@ -116,6 +126,8 @@ class ALKLinkView: UIView, Localizable {
     }
 
     func update(url: String?, identifier: String) {
+        currentURL = url
+        currentIdentifier = identifier
         loadingIndicator.startLoading(localizationFileName: localizedStringFileName)
         hideViews(true)
         guard let linkUrl = url else {
@@ -124,6 +136,7 @@ class ALKLinkView: UIView, Localizable {
             return
         }
         guard let cachelinkPreviewMeta = LinkURLCache.getLink(for: linkUrl) else {
+            let placeHolder = UIImage(named: "default_image", in: Bundle.km, compatibleWith: nil)
             let linkview = ALKLinkPreviewManager()
             linkview.makePreview(from: linkUrl, identifier: identifier) { [weak self] result in
                 guard let weakSelf = self, let isViewCellVisible = weakSelf.isViewCellVisible, isViewCellVisible(identifier) else { return }
@@ -131,6 +144,7 @@ class ALKLinkView: UIView, Localizable {
                 case let .success(linkPreviewMeta):
                     weakSelf.updateView(linkPreviewMeta: linkPreviewMeta)
                 case .failure:
+                    self?.previewImageView.image = placeHolder
                     weakSelf.updateFailedStatusInView()
                     weakSelf.loadingIndicator.stopLoading()
                 }

--- a/Sources/Views/ALKLinkView.swift
+++ b/Sources/Views/ALKLinkView.swift
@@ -141,8 +141,8 @@ class ALKLinkView: UIView, Localizable {
             linkview.makePreview(from: linkUrl, identifier: identifier) { [weak self] result in
                 guard let weakSelf = self, let isViewCellVisible = weakSelf.isViewCellVisible, isViewCellVisible(identifier) else { return }
                 switch result {
-                case let .success(linkPreviewMeta):
-                    weakSelf.updateView(linkPreviewMeta: linkPreviewMeta)
+                case let .success(linkPreviewData):
+                    weakSelf.updateView(linkPreviewMeta: linkPreviewData.0, linkPreviewURL: linkPreviewData.1.absoluteString)
                 case .failure:
                     self?.previewImageView.image = placeHolder
                     weakSelf.updateFailedStatusInView()
@@ -151,7 +151,7 @@ class ALKLinkView: UIView, Localizable {
             }
             return
         }
-        updateView(linkPreviewMeta: cachelinkPreviewMeta)
+        updateView(linkPreviewMeta: cachelinkPreviewMeta, linkPreviewURL: linkUrl)
     }
 
     func hideViews(_ isHide: Bool) {
@@ -164,10 +164,10 @@ class ALKLinkView: UIView, Localizable {
         return ALKLinkView.CommonPadding.View.height + ALKLinkView.CommonPadding.PreviewImageView.top
     }
 
-    func updateView(linkPreviewMeta: LinkPreviewMeta) {
+    func updateView(linkPreviewMeta: LinkPreviewMeta, linkPreviewURL:  String) {
         let placeHolder = UIImage(named: "default_image", in: Bundle.km, compatibleWith: nil)
 
-        if let stringURL = linkPreviewMeta.image ?? linkPreviewMeta.icon, let url = URL(string: stringURL) {
+        if let stringURL = linkPreviewMeta.image ?? linkPreviewMeta.icon, let url = URL(string: stringURL), currentURL == linkPreviewURL {
             let resource = Kingfisher.ImageResource(downloadURL: url, cacheKey: url.absoluteString)
             previewImageView.kf.setImage(with: resource, placeholder: placeHolder)
         } else {


### PR DESCRIPTION
## Summary
- Fixed the Link Preview now it will automatically update the UI when there is change in view.
- Added a check for the URL's to match the correct linkPreviewMeta for the cell's.

## Video (Before - After)

### Before
https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/90a58674-23c7-4e01-9cd0-cb12a6508eff

### After
https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/f9487bcd-1602-40bf-a4a8-64f420fd175c

