### PR TITLE
Fixed assignee image is not getting rendered on conversation list when it is created with title

### DIFF
--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -276,13 +276,16 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
         let placeHolder = placeholderImage(placeholder, viewModel: viewModel)
         
         if let avatarImage = viewModel.avatarImage {
-            if let imgStr = viewModel.avatarGroupImageUrl, let imgURL = URL(string: imgStr) {
+              if let imgStr = viewModel.avatarGroupImageUrl, let imgURL = URL(string: imgStr) {
                 let resource = Kingfisher.ImageResource(downloadURL: imgURL, cacheKey: imgStr)
                 avatarImageView.kf.setImage(with: resource, placeholder: avatarImage)
-            } else {
+              } else if let avatar = viewModel.avatar {
+                let resource = Kingfisher.ImageResource(downloadURL: avatar, cacheKey: avatar.absoluteString)
+                avatarImageView.kf.setImage(with: resource, placeholder: placeHolder)
+              } else {
                 avatarImageView.image = placeHolder
-            }
-        } else if let avatar = viewModel.avatar {
+              }
+            } else if let avatar = viewModel.avatar {
             let resource = Kingfisher.ImageResource(downloadURL: avatar, cacheKey: avatar.absoluteString)
             avatarImageView.kf.setImage(with: resource, placeholder: placeHolder)
         } else {


### PR DESCRIPTION
## Summary
- Fixed assignee image is not getting rendered on conversation list when it is created with title.
- Instead placeholder image is getting rendered.


## issue
<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/be8977ad-5e0c-4c79-8aae-9ec3e9e98ac5" width=200 height=400/>


## After fix

<img src="https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/121929127/80cebc77-404e-4292-b789-ebdea1f102bc" width=200 height=400/>
