### PR TITLE
Updated ChatUI PodFile to 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
+## [1.2.9] 2024-03-11
+- Added the last Message icon in Conversation List Screen.
+- Fixed Link preview issue. 
+- Fixed Assignee Image not showing with custom title.
+
 ## [1.2.8] 2024-02-21
 - Fixed Form Rich Message Rendering issue
 - Added support for showing assingment message 

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -15,16 +15,16 @@ PODS:
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
   - Kingfisher (7.6.2)
-  - KommunicateChatUI-iOS-SDK (1.2.8):
-    - KommunicateChatUI-iOS-SDK/Complete (= 1.2.8)
-  - KommunicateChatUI-iOS-SDK/Complete (1.2.8):
+  - KommunicateChatUI-iOS-SDK (1.2.9):
+    - KommunicateChatUI-iOS-SDK/Complete (= 1.2.9)
+  - KommunicateChatUI-iOS-SDK/Complete (1.2.9):
     - iOSDropDown
     - Kingfisher (~> 7.6.2)
     - KommunicateChatUI-iOS-SDK/RichMessageKit
     - KommunicateCore-iOS-SDK (~> 1.1.8)
     - SwipeCellKit (~> 2.7.1)
     - ZendeskChatProvidersSDK (~> 3.0.0)
-  - KommunicateChatUI-iOS-SDK/RichMessageKit (1.2.8)
+  - KommunicateChatUI-iOS-SDK/RichMessageKit (1.2.9)
   - KommunicateCore-iOS-SDK (1.1.8)
   - Nimble (13.1.2):
     - CwlPreconditionTesting (~> 2.1.0)
@@ -79,7 +79,7 @@ SPEC CHECKSUMS:
   iOSDropDown: ce9daa584eaa5567cafc1b633e3cc7eb6d9cea42
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
-  KommunicateChatUI-iOS-SDK: b582ccc1cc2797adfa2caa97fcf1ed884bf56ebd
+  KommunicateChatUI-iOS-SDK: c136dcb1e2bea0a00e9d53855fdafdfce826e28a
   KommunicateCore-iOS-SDK: 87c6e7c9f0e1e32d258c36b70ba20ffbd4428c90
   Nimble: d733c860d832b324e9779034f12398993c536e7b
   Nimble-Snapshots: 7f2710c507469eb0fc4912f45d0f280e15f91966
@@ -91,4 +91,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 8d7027df7ae3a22900b6d9071fcc30c1c76341ab
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.13.0

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'KommunicateChatUI-iOS-SDK'
-  s.version = '1.2.8'
+  s.version = '1.2.9'
   s.license = { :type => "BSD 3-Clause", :file => "LICENSE" }
   s.summary = 'KommunicateChatUI-iOS-SDK Kit'
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'


### PR DESCRIPTION
## Summary
- Added the last Message icon in Conversation List Screen.
- Fixed Link preview issue. 
- Fixed Assignee Image not showing with custom title.
