### PR TITLE
[CM-824] Show tags on conversation list same as that on dashboard | iOS Agent App 

### DIFF
--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -227,9 +227,9 @@ extension ALMessage: ALKChatViewModelProtocol {
         guard let channel = ALChannelService().getChannelByKey(channelKey),
               let tags = channel.metadata.value(forKey: "KM_TAGS") as? String,
               let data = tags.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] else { return nil }
+              let tagsList = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] else { return nil }
         var tagsArray = [KMAssignedTags]()
-        for tag in json {
+        for tag in tagsList {
             if let id = tag["id"] as? Int,
                let name = tag["name"] as? String,
                let color = tag["color"] as? String {

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -222,6 +222,23 @@ extension ALMessage: ALKChatViewModelProtocol {
         let source = sourceChannel.platformSource
         return source
     }
+    
+    public var assignedTags: [KMAssignedTags]? {
+        guard let channel = ALChannelService().getChannelByKey(channelKey),
+              let tags = channel.metadata.value(forKey: "KM_TAGS") as? String,
+              let data = tags.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [[String: Any]] else { return nil }
+        var tagsArray = [KMAssignedTags]()
+        for tag in json {
+            if let id = tag["id"] as? Int,
+               let name = tag["name"] as? String,
+               let color = tag["color"] as? String {
+                let tag = KMAssignedTags(id: id, name: name, color: color)
+                tagsArray.append(tag)
+            }
+        }
+        return tagsArray
+    }
 }
 
 extension ALMessage {
@@ -491,4 +508,10 @@ extension ALMessage {
             return false
         }
     }
+}
+
+public struct KMAssignedTags {
+    public let id: Int
+    public let name: String
+    public let color: String?
 }

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -30,6 +30,7 @@ public protocol ALKChatViewModelProtocol {
     var isMessageEmpty: Bool { get }
     var messageMetadata: NSMutableDictionary? { get }
     var platformSource: String? { get }
+    var assignedTags: [KMAssignedTags]? { get }
 }
 
 extension ALKChatViewModelProtocol {


### PR DESCRIPTION
## Summary
- Added in protocol to fetch the tags assigned to the conversation.