### PR TITLE
[CM-1959] Iframe Support for HTML Content 

### DIFF
--- a/Sources/Views/ALKFriendMessageCell.swift
+++ b/Sources/Views/ALKFriendMessageCell.swift
@@ -101,6 +101,7 @@ open class ALKFriendMessageCell: ALKMessageCell {
         avatarImageView.addGestureRecognizer(tapGesture)
 
         contentView.addViewsForAutolayout(views: [avatarImageView, nameLabel])
+        contentView.bringSubviewToFront(iframeView)
         contentView.bringSubviewToFront(messageView)
 
         NSLayoutConstraint.activate([
@@ -212,7 +213,19 @@ open class ALKFriendMessageCell: ALKMessageCell {
                 constant: 0,
                 identifier: ConstraintIdentifier.ReplyMessageLabel.height
             ),
-
+            iframeView.topAnchor.constraint(
+                equalTo: bubbleView.topAnchor
+            ),
+            iframeView.bottomAnchor.constraint(
+                equalTo: bubbleView.bottomAnchor
+            ),
+            iframeView.trailingAnchor.constraint(
+                equalTo: bubbleView.trailingAnchor
+            ),
+            iframeView.leadingAnchor.constraint(
+                equalTo: bubbleView.leadingAnchor
+            ),
+            iframeWidth,
             emailTopView.topAnchor.constraint(
                 equalTo: replyView.bottomAnchor,
                 constant: Padding.MessageView.top

--- a/Sources/Views/ALKFriendMessageCell.swift
+++ b/Sources/Views/ALKFriendMessageCell.swift
@@ -213,18 +213,10 @@ open class ALKFriendMessageCell: ALKMessageCell {
                 constant: 0,
                 identifier: ConstraintIdentifier.ReplyMessageLabel.height
             ),
-            iframeView.topAnchor.constraint(
-                equalTo: bubbleView.topAnchor
-            ),
-            iframeView.bottomAnchor.constraint(
-                equalTo: bubbleView.bottomAnchor
-            ),
-            iframeView.trailingAnchor.constraint(
-                equalTo: bubbleView.trailingAnchor
-            ),
-            iframeView.leadingAnchor.constraint(
-                equalTo: bubbleView.leadingAnchor
-            ),
+            iframeView.topAnchor.constraint(equalTo: bubbleView.topAnchor),
+            iframeView.bottomAnchor.constraint(equalTo: bubbleView.bottomAnchor),
+            iframeView.trailingAnchor.constraint(equalTo: bubbleView.trailingAnchor),
+            iframeView.leadingAnchor.constraint(equalTo: bubbleView.leadingAnchor),
             iframeWidth,
             emailTopView.topAnchor.constraint(
                 equalTo: replyView.bottomAnchor,

--- a/Sources/Views/ALKMessageBaseCell.swift
+++ b/Sources/Views/ALKMessageBaseCell.swift
@@ -104,6 +104,7 @@ open class ALKMessageCell: ALKChatBaseCell<ALKMessageViewModel> {
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.isUserInteractionEnabled = true
         webView.isOpaque = true
+        webView.scrollView.isScrollEnabled = false
         return webView
     }()
 


### PR DESCRIPTION
## Summary
- Added support for Iframe Contents.

## Images (Before - After)

<img src='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/7045499f-268c-42d7-af19-b7e8fed8c1de' width=250 > <img src='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/5e8037e6-c6b5-4908-995c-74ff6a6c2d55' width=250 > 
