### PR TITLE
Changed Default Text Color of send message to white.

### DIFF
--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -35,7 +35,7 @@ public enum ALKMessageStyle {
     // Sent message text style
     public static var sentMessage = Style(
         font: UIFont.font(.normal(size: 14)),
-        text: .text(.black00)
+        text: .text(.white)
     )
 
     /// Style for mentions in sent message text


### PR DESCRIPTION
## Summary
- Changed color of send message text color to white previously it was black. 
- Previously the color is updated when we call this function `Kommunicate.setup(applicationId: applicationId)`.


## Image (Before - After)
<img src='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/2edeb477-6a14-4cbd-ae4d-820882a9ecc6' width=250 > <img src='https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/a3a82c0d-cea6-405f-93fa-6cffaf37f2c7' width=250 > 




