### PR TITLE
[CM-1453] Expose a function to show/hide attachment options

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -436,6 +436,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
     
     open func updateAssigneeDetails() {
+        if configuration.chatBar.hideAttachmentOptionsForBotConvesations {
+            chatBar.hideAllAttachmentButtonIcons(isHidden: viewModel.isBotHandelingConversation())
+        }
         self.viewModel.currentConversationProfile(completion: { profile in
             guard let profile = profile else { return }
             self.navigationBar.updateView(profile: profile)
@@ -864,6 +867,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func prepareChatBar() {
+        if configuration.chatBar.hideAttachmentOptionsForBotConvesations {
+            chatBar.hideAllAttachmentButtonIcons(isHidden: viewModel.isBotHandelingConversation())
+        }
         // Update ChatBar's top view which contains send button and the text view.
         chatBar.grayView.backgroundColor = UIColor.kmDynamicColor(light: configuration.backgroundColor, dark: configuration.backgroundDarkColor)
 

--- a/Sources/Models/ALKChatBarConfiguration.swift
+++ b/Sources/Models/ALKChatBarConfiguration.swift
@@ -31,6 +31,7 @@ public struct ALKChatBarConfiguration {
         case some([AttachmentType])
     }
 
+    /// if true then Attachment Options Will be hidden when bot is handeling the conversartion. By Default the value is False.
     public var hideAttachmentOptionsForBotConvesations = false
     
     /// If true then button tint color will be disabled for attachment buttons, send button.

--- a/Sources/Models/ALKChatBarConfiguration.swift
+++ b/Sources/Models/ALKChatBarConfiguration.swift
@@ -31,6 +31,8 @@ public struct ALKChatBarConfiguration {
         case some([AttachmentType])
     }
 
+    public var hideAttachmentOptionsForBotConvesations = false
+    
     /// If true then button tint color will be disabled for attachment buttons, send button.
     public var disableButtonTintColor = false
     

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1536,6 +1536,17 @@ open class ALKConversationViewModel: NSObject, Localizable {
         }
         return false
     }
+    
+    func isBotHandelingConversation() -> Bool {
+        if let channel = ALChannelService().getChannelByKey(channelKey),
+        let assigneeUserId = channel.assigneeUserId,
+        let assignee = ALContactService().loadContact(byKey: "userId", value: assigneeUserId),
+        let roleType = assignee.roleType,
+        roleType ==  NSNumber.init(value: AL_BOT.rawValue) {
+            return true
+        }
+        return false
+    }
 
     func loadSearchMessages() {
         var time: NSNumber?

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -381,6 +381,10 @@ open class ALKChatBar: UIView, Localizable {
         comingSoonDelegate = delegate
     }
 
+    open func hideAllAttachmentButtonIcons(isHidden: Bool) {
+        attachmentButtonStackView.isHidden = isHidden
+    }
+    
     open func clear() {
         textView.text = ""
         clearTextInTextView()


### PR DESCRIPTION
## Summary
- Added Customisation to hide attachment options when bot is replying to the conversation.
- Customisation Code :  `Kommunicate.defaultConfiguration.chatBar.hideAttachmentOptionsForBotConvesations = true`

## Video


https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/069a8f4c-597b-4fc2-b626-0db452f8b2ef

