### PR TITLE
Fixed Sent Message Colour issue

### DIFF
--- a/Sources/Utilities/ALKAppSettingsUserDefaults.swift
+++ b/Sources/Utilities/ALKAppSettingsUserDefaults.swift
@@ -40,8 +40,8 @@ public struct ALKAppSettingsUserDefaults {
     
     /// CSAT Rating Base
     public func getCSATRatingBase() -> Int {
-        if let appSettings = getAppSettings(), let csatRatingBase = appSettings.csatRatingBase {
-            return csatRatingBase
+        if let appSettings = getAppSettings(){
+            return appSettings.csatRatingBase
         }
         return 3
     }
@@ -236,7 +236,7 @@ public class ALKAppSettings: NSObject, NSCoding {
     public var hidePostCTAEnabled: Bool = false
     public var defaultUploadOverrideUrl: String?
     public var defaultUploadOverrideHeaders: [String:String]?
-    public var csatRatingBase: Int?
+    public var csatRatingBase: Int = 3
 
     // MARK: - Public Initialization
 

--- a/Sources/Utilities/Message+Style.swift
+++ b/Sources/Utilities/Message+Style.swift
@@ -110,7 +110,7 @@ public enum ALKMessageStyle {
 
     public struct Bubble {
         enum DefaultColor {
-            static let sentBubbleColor = UIColor(netHex: 0xF1F0F0)
+            static let sentBubbleColor = UIColor(netHex: 0x5553B7)
             static let receivedBubbleColor = UIColor(netHex: 0xF1F0F0)
         }
 
@@ -144,7 +144,7 @@ public enum ALKMessageStyle {
         }
     }
 
-    public static var sentBubble = Bubble(color: UIColor(netHex: 0xF1F0F0), style: .edge) {
+    public static var sentBubble = Bubble(color: UIColor(netHex: 0x5553B7), style: .edge) {
         didSet {
             let appSettingsUserDefaults = ALKAppSettingsUserDefaults()
             appSettingsUserDefaults.setSentMessageBackgroundColor(color: sentBubble.color)


### PR DESCRIPTION
## Summary
- Updated sent message Colour. Previously the color was `0xF1F0F0` now `0x5553B7`
- added default value of `csatRatingBase` to 3. Creating issue when that is not available in AppSetting Api Call.