### PR TITLE
[CM-1827] In App Notification Banner Colour Customization

### DIFF
--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -173,26 +173,26 @@ public struct ALKConfiguration {
     // If true, then in-app notification banner will be disabled
     public var isInAppNotificationBannerDisabled: Bool = false
 
-    /// Set The In App Banner Color. By Default the color is black.
-    public var inAppBannerColor: UIColor = UIColor.black
+    /// Set The In App Banner Color. By default the color is white and in dark mode it's black (only if dark mode is enabled).
+    public var inAppBannerColor: UIColor = UIColor.kmDynamicColor(light: UIColor(netHex: 0xFFFFFF), dark: UIColor(netHex: 0x1D1B20))
     
-    /// Set The In App Banner Shadow Color. By Default the color is black.
-    public var inAppBannerShadowColor: UIColor = UIColor.black
+    /// Set The In App Banner Shadow Color. By default the color is gray.
+    public var inAppBannerShadowColor: UIColor = UIColor(netHex: 0x2C2C2C)
 
-    /// Set The In App Banner Shadow radius. By Default the value is 2.
-    public var inAppBannerShadowRadius: NSNumber = 2
+    /// Set The In App Banner Shadow radius. By default the value is 4.
+    public var inAppBannerShadowRadius: NSNumber = 4
     
-    /// Set The In App Banner Shadow radius. By Default the value is 12.
-    public var inAppBannerRadius: NSNumber = 12
+    /// Set The In App Banner Shadow radius. By default the value is 8.
+    public var inAppBannerRadius: NSNumber = 8
     
-    /// Set The In App Banner Shadow Opacity. By Default the value is 0.5.
-    public var inAppBannerShadowOpacity: NSNumber = 0.5
+    /// Set The In App Banner Shadow Opacity. By default the value is 0.25.
+    public var inAppBannerShadowOpacity: NSNumber = 0.25
     
-    /// Set The In App Banner Text Color. By Default the color is white.
-    public var inAppBannerTextColor: UIColor = UIColor.white
+    /// Set The In App Banner Text Color. By default the color is black for light mode and white for dark mode (only if dark mode is enabled).
+    public var inAppBannerTextColor: UIColor = UIColor.kmDynamicColor(light: UIColor(netHex: 0x313131), dark: UIColor(netHex: 0xEFEFEF))
     
-    /// Set The In App Banner Content Color. By Default the color is white.
-    public var inAppBannerContentColor: UIColor = UIColor.white
+    /// Set The In App Banner Content Color. By default the color is black for light mode and white for dark mode (only if dark mode is enabled).
+    public var inAppBannerContentColor: UIColor = UIColor.kmDynamicColor(light: UIColor(netHex: 0x67757E), dark: UIColor(netHex: 0xB3B3B3))
     
     // If true, then link preview will be disabled
     public var isLinkPreviewDisabled: Bool = false

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -173,6 +173,15 @@ public struct ALKConfiguration {
     // If true, then in-app notification banner will be disabled
     public var isInAppNotificationBannerDisabled: Bool = false
 
+    /// Set The In App Banner Color. By Default the color is black.
+    public var inAppBannerColor: UIColor = UIColor.black
+    
+    /// Set The In App Banner Text Color. By Default the color is white.
+    public var inAppBannerTextColor: UIColor = UIColor.white
+    
+    /// Set The In App Banner Content Color. By Default the color is white.
+    public var inAppBannerContentColor: UIColor = UIColor.white
+    
     // If true, then link preview will be disabled
     public var isLinkPreviewDisabled: Bool = false
 

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -179,14 +179,14 @@ public struct ALKConfiguration {
     /// Set The In App Banner Shadow Color. By Default the color is black.
     public var inAppBannerShadowColor: UIColor = UIColor.black
 
-    /// Set The In App Banner Shadow radius. By Default the value is 0.
-    public var inAppBannerShadowRadius: NSNumber = 0
+    /// Set The In App Banner Shadow radius. By Default the value is 2.
+    public var inAppBannerShadowRadius: NSNumber = 2
     
-    /// Set The In App Banner Shadow radius. By Default the value is 0.
-    public var inAppBannerRadius: NSNumber = 0
+    /// Set The In App Banner Shadow radius. By Default the value is 12.
+    public var inAppBannerRadius: NSNumber = 12
     
-    /// Set The In App Banner Shadow Opacity. By Default the value is 0.
-    public var inAppBannerOpacity: NSNumber = 0
+    /// Set The In App Banner Shadow Opacity. By Default the value is 0.5.
+    public var inAppBannerShadowOpacity: NSNumber = 0.5
     
     /// Set The In App Banner Text Color. By Default the color is white.
     public var inAppBannerTextColor: UIColor = UIColor.white

--- a/Sources/Models/ALKConfiguration.swift
+++ b/Sources/Models/ALKConfiguration.swift
@@ -176,6 +176,18 @@ public struct ALKConfiguration {
     /// Set The In App Banner Color. By Default the color is black.
     public var inAppBannerColor: UIColor = UIColor.black
     
+    /// Set The In App Banner Shadow Color. By Default the color is black.
+    public var inAppBannerShadowColor: UIColor = UIColor.black
+
+    /// Set The In App Banner Shadow radius. By Default the value is 0.
+    public var inAppBannerShadowRadius: NSNumber = 0
+    
+    /// Set The In App Banner Shadow radius. By Default the value is 0.
+    public var inAppBannerRadius: NSNumber = 0
+    
+    /// Set The In App Banner Shadow Opacity. By Default the value is 0.
+    public var inAppBannerOpacity: NSNumber = 0
+    
     /// Set The In App Banner Text Color. By Default the color is white.
     public var inAppBannerTextColor: UIColor = UIColor.white
     

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -39,6 +39,10 @@ public class ALKPushNotificationHandler: Localizable {
                     titleTest: configuration.inAppBannerTextColor,
                     contentTextColor: configuration.inAppBannerContentColor,
                     backgroundColor: configuration.inAppBannerColor,
+                    backgroundShadowColor: configuration.inAppBannerShadowColor,
+                    shadowRadius: configuration.inAppBannerShadowRadius,
+                    cornerRadius: configuration.inAppBannerRadius,
+                    shadowOpacity: configuration.inAppBannerOpacity,
                     completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -36,6 +36,9 @@ public class ALKPushNotificationHandler: Localizable {
                     message,
                     andForContactId: notificationData.userId,
                     withGroupId: notificationData.groupId,
+                    titleTest: configuration.inAppBannerTextColor,
+                    contentTextColor: configuration.inAppBannerContentColor,
+                    backgroundColor: configuration.inAppBannerColor,
                     completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)

--- a/Sources/Utilities/ALKPushNotificationHandler.swift
+++ b/Sources/Utilities/ALKPushNotificationHandler.swift
@@ -42,7 +42,7 @@ public class ALKPushNotificationHandler: Localizable {
                     backgroundShadowColor: configuration.inAppBannerShadowColor,
                     shadowRadius: configuration.inAppBannerShadowRadius,
                     cornerRadius: configuration.inAppBannerRadius,
-                    shadowOpacity: configuration.inAppBannerOpacity,
+                    shadowOpacity: configuration.inAppBannerShadowOpacity,
                     completionHandler: {
                         _ in
                         weakSelf.launchIndividualChatWith(notificationData: notificationData)


### PR DESCRIPTION
## Summary
- Added Customisation to update color of in App Banner. Customisation is accessible for Background Color, Title Color, Content Color.

## Code
```
            Kommunicate.defaultConfiguration.inAppBannerColor = UIColor.kmDynamicColor(light: .systemBrown, dark: .systemBlue)
            Kommunicate.defaultConfiguration.inAppBannerTextColor = UIColor.kmDynamicColor(light: .white, dark: .black)
            Kommunicate.defaultConfiguration.inAppBannerContentColor = UIColor.kmDynamicColor(light: .white, dark: .black)
            Kommunicate.defaultConfiguration.inAppBannerRadius = 12
            Kommunicate.defaultConfiguration.inAppBannerShadowRadius = 15
            Kommunicate.defaultConfiguration.inAppBannerOpacity = 0.5
            Kommunicate.defaultConfiguration.inAppBannerShadowColor = UIColor.kmDynamicColor(light: .black, dark: .red)
```

## Images (Before and After Customisation)

<img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/e80bfbc4-8b8f-4907-ad61-6553fee148fb' height = 400/> <img src = 'https://github.com/Kommunicate-io/Kommunicate-iOS-SDK/assets/139110221/e84f4402-2b20-47db-a079-20d5773e3a7d' height = 400/>

## Video

https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK/assets/139110221/ff0251e1-f055-460c-bba7-aec257953dd4

