### PR TITLE
[CM-2048] Time, Date Format on conversation screen similar to Android & Web

### DIFF
--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -286,7 +286,7 @@ extension ALMessage {
 
     var time: String? {
         let dateFormatterGet = DateFormatter()
-        dateFormatterGet.dateFormat = "HH:mm"
+        dateFormatterGet.dateFormat = "h:mm a"
         return dateFormatterGet.string(from: date)
     }
 

--- a/Sources/Utilities/Date+Extension.swift
+++ b/Sources/Utilities/Date+Extension.swift
@@ -53,7 +53,7 @@ extension Date {
             dateFormatter.dateStyle = .medium
             dateFormatter.doesRelativeDateFormatting = true
         } else {
-            let fromTemplate = (day < 7 ? "EEEE" : "EdMMM")
+            let fromTemplate = (day < 7 ? "EEEE" : "EEEE MMM dd, yyyy")
             let dateFormat = DateFormatter.dateFormat(fromTemplate: fromTemplate, options: 0, locale: Locale.current)
             dateFormatter.dateFormat = dateFormat
         }


### PR DESCRIPTION
## Summary
- Time label for messages are updated to 12hr format from 24hr format.
- In conversation screen date label is added with Year as well.

## Images (Before - After)


<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/5c010e8f-a9cc-421a-94bc-c2dde5f1820e' height = 400/> <img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/0c1664c8-4acb-4291-b552-28f8d111ec95' height = 400/>

