### PR TITLE
[CM-2072] Show answer source url with bot answer 

### DIFF
--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -74,7 +74,7 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 return cell
 
-            } else if let messageMetadata = message.metadata, let _ = messageMetadata["sourceURLs"], !message.isMyMessage {
+            } else if let messageMetadata = message.metadata, let _ = messageMetadata[KMSourceURLIdentifier.sourceURLIdentifier], !message.isMyMessage {
                 var cell = KMFriendSourceURLViewCell()
                 cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as KMFriendSourceURLViewCell
                 cell.showReport = true

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -74,6 +74,16 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
                 }
                 return cell
 
+            } else if let messageMetadata = message.metadata, let _ = messageMetadata["sourceURLs"], !message.isMyMessage {
+                var cell = KMFriendSourceURLViewCell()
+                cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as KMFriendSourceURLViewCell
+                cell.showReport = true
+                cell.avatarTapped = { [weak self] in
+                    guard let currentModel = cell.viewModel else { return }
+                    self?.messageAvatarViewDidTap(messageVM: currentModel, indexPath: indexPath)
+                }
+                necessarySetupForMessageCell(cell: cell, message: message)
+                return cell
             } else {
                 if message.isMyMessage {
                     let cell = tableView.dequeueReusableCell(forIndexPath: indexPath) as ALKMyMessageCell

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -844,6 +844,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         tableView.register(KMStaticTopMessageCell.self)
         tableView.register(KMMyVideoTemplateCell.self)
         tableView.register(KMFriendVideoTemplateCell.self)
+        tableView.register(KMFriendSourceURLViewCell.self)
         tableView.register(KMTypingIndicator.self)
     }
 

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -98,6 +98,7 @@ AreTyping = " are typing";
 Copy = "Copy";
 Reply = "Reply";
 You = "You";
+Source = "Source";
 
 NotPartOfGroup = "You are not part of this group";
 MuteChannel = "Mute group %@";

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -180,6 +180,7 @@ struct SystemMessage: Localizable {
         static let DatePickerTimeTitle = localizedString(forKey: "DatePickerTimeTitle")
         static let DatePickerDateTitle = localizedString(forKey: "DatePickerDateTitle")
         static let DatePickerDateAndTimeTitle = localizedString(forKey: "DatePickerDateAndTimeTitle")
+        static let Source = localizedString(forKey: "Source")
     }
 
     enum Mute {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -314,6 +314,12 @@ open class ALKConversationViewModel: NSObject, Localizable {
         switch messageModel.messageType {
         case .text, .html, .email:
             guard !configuration.isLinkPreviewDisabled, messageModel.messageType == .text, ALKLinkPreviewManager.extractURLAndAddInCache(from: messageModel.message, identifier: messageModel.identifier) != nil else {
+                if let messageMetadata = messageModel.metadata, let metadataValue = messageMetadata["sourceURLs"], !messageModel.isMyMessage {
+                    let height = KMFriendSourceURLViewCell.rowHeigh(viewModel: messageModel, width: maxWidth, displayNames: { userIds in
+                        self.displayNames(ofUserIds: userIds)
+                    })
+                    return height.cached(with: cacheIdentifier)
+                }
                 if messageModel.isMyMessage {
                     let height = ALKMyMessageCell.rowHeigh(viewModel: messageModel, width: maxWidth, displayNames: { userIds in
                         self.displayNames(ofUserIds: userIds)

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -314,7 +314,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         switch messageModel.messageType {
         case .text, .html, .email:
             guard !configuration.isLinkPreviewDisabled, messageModel.messageType == .text, ALKLinkPreviewManager.extractURLAndAddInCache(from: messageModel.message, identifier: messageModel.identifier) != nil else {
-                if let messageMetadata = messageModel.metadata, let metadataValue = messageMetadata["sourceURLs"], !messageModel.isMyMessage {
+                if let messageMetadata = messageModel.metadata, let metadataValue = messageMetadata[KMSourceURLIdentifier.sourceURLIdentifier], !messageModel.isMyMessage {
                     let height = KMFriendSourceURLViewCell.rowHeigh(viewModel: messageModel, width: maxWidth, displayNames: { userIds in
                         self.displayNames(ofUserIds: userIds)
                     })

--- a/Sources/Views/KMFriendSourceURLViewCell.swift
+++ b/Sources/Views/KMFriendSourceURLViewCell.swift
@@ -9,6 +9,10 @@ import Kingfisher
 import KommunicateCore_iOS_SDK
 import UIKit
 
+public struct KMSourceURLIdentifier {
+    public static let sourceURLIdentifier: String = "sourceURLs"
+}
+
 open class KMFriendSourceURLViewCell: ALKMessageCell {
     private var avatarImageView: UIImageView = {
         let imv = UIImageView()
@@ -364,7 +368,7 @@ open class KMFriendSourceURLViewCell: ALKMessageCell {
         nameLabel.text = viewModel.displayName
         var urls = [""]
         
-        if let messageMetadata = viewModel.metadata, let metadataValue = messageMetadata["sourceURLs"] as? [String] {
+        if let messageMetadata = viewModel.metadata, let metadataValue = messageMetadata[KMSourceURLIdentifier.sourceURLIdentifier] as? [String] {
             urls = metadataValue
         }
         urlStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -408,7 +412,7 @@ open class KMFriendSourceURLViewCell: ALKMessageCell {
         
         /// For calculating the height according to the number of urls
         var urlCount = 0
-        if let messageMetadata = viewModel.metadata, let metadataValue = messageMetadata["sourceURLs"] as? [String] {
+        if let messageMetadata = viewModel.metadata, let metadataValue = messageMetadata[KMSourceURLIdentifier.sourceURLIdentifier] as? [String] {
             urlCount = metadataValue.count
         }
         

--- a/Sources/Views/KMFriendSourceURLViewCell.swift
+++ b/Sources/Views/KMFriendSourceURLViewCell.swift
@@ -1,0 +1,485 @@
+//
+//  KMFriendSourceURLViewCell.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by Abhijeet Ranjan on 24/06/24.
+//
+
+import Kingfisher
+import KommunicateCore_iOS_SDK
+import UIKit
+
+open class KMFriendSourceURLViewCell: ALKMessageCell {
+    private var avatarImageView: UIImageView = {
+        let imv = UIImageView()
+        imv.contentMode = .scaleAspectFill
+        imv.clipsToBounds = true
+        let layer = imv.layer
+        layer.cornerRadius = 18.5
+        layer.masksToBounds = true
+        imv.isUserInteractionEnabled = true
+        return imv
+    }()
+
+    private var nameLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 1
+        label.isOpaque = true
+        return label
+    }()
+
+    enum Padding {
+        enum NameLabel {
+            static let top: CGFloat = 6.0
+            static let left: CGFloat = 57.0
+            static let right: CGFloat = 57.0
+            static let height: CGFloat = 16.0
+        }
+        
+        enum OperationLineView {
+            static let top: CGFloat = 10.0
+            static let height: CGFloat = 1
+        }
+        
+        enum SourceLableView {
+            static let top: CGFloat = 10.0
+        }
+
+        enum AvatarImage {
+            static let top: CGFloat = 18.0
+            static let left: CGFloat = 9.0
+            static let width: CGFloat = 37.0
+            static let height: CGFloat = 37.0
+        }
+
+        enum BubbleView {
+            static let left: CGFloat = 5.0
+            static let right: CGFloat = 95.0
+            static let bottom: CGFloat = 5.0
+        }
+        
+        enum SourceView {
+            static let height: CGFloat = 50
+        }
+        
+        enum SourceURLView {
+            static let top: CGFloat = 5.0
+        }
+
+        enum ReplyView {
+            static let left: CGFloat = 5.0
+            static let right: CGFloat = 5.0
+            static let top: CGFloat = 5.0
+            static let height: CGFloat = 80.0
+        }
+
+        enum ReplyNameLabel {
+            static let right: CGFloat = 10.0
+            static let height: CGFloat = 30.0
+        }
+
+        enum ReplyMessageLabel {
+            static let right: CGFloat = 10.0
+            static let top: CGFloat = 5.0
+            static let height: CGFloat = 30.0
+        }
+
+        enum PreviewImageView {
+            static let height: CGFloat = 50.0
+            static let width: CGFloat = 70.0
+            static let right: CGFloat = 5.0
+            static let top: CGFloat = 10.0
+        }
+
+        enum MessageView {
+            static let top: CGFloat = 5
+            static let bottom: CGFloat = 10
+        }
+
+        enum TimeLabel {
+            static let bottom: CGFloat = 2
+            static let left: CGFloat = 10
+        }
+        enum URLView {
+            static let height: CGFloat = 20
+        }
+    }
+    
+    private var operationLineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(netHex: 0xDCDCDC)
+        return view
+    }()
+
+    private var sourceLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor(netHex: 0x313131)
+        label.text = "Source"
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        return label
+    }()
+    
+    private let urlStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 5
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    static let bubbleViewLeftPadding: CGFloat = {
+        /// For edge add extra 5
+        guard ALKMessageStyle.receivedBubble.style == .edge else {
+            return ALKMessageStyle.receivedBubble.widthPadding
+        }
+        return ALKMessageStyle.receivedBubble.widthPadding + 5
+    }()
+
+    override func setupViews() {
+        super.setupViews()
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(avatarTappedAction))
+        avatarImageView.addGestureRecognizer(tapGesture)
+
+        contentView.addViewsForAutolayout(views: [avatarImageView, nameLabel, operationLineView, sourceLabel, urlStackView])
+        contentView.bringSubviewToFront(iframeView)
+        contentView.bringSubviewToFront(messageView)
+
+        NSLayoutConstraint.activate([
+            nameLabel.topAnchor.constraint(
+                equalTo: contentView.topAnchor,
+                constant: Padding.NameLabel.top
+            ),
+            nameLabel.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: Padding.NameLabel.left
+            ),
+            nameLabel.trailingAnchor.constraint(
+                equalTo: contentView.trailingAnchor,
+                constant: -Padding.NameLabel.right
+            ),
+            nameLabel.heightAnchor.constraint(equalToConstant: Padding.NameLabel.height),
+
+            avatarImageView.topAnchor.constraint(
+                equalTo: contentView.topAnchor,
+                constant: Padding.AvatarImage.top
+            ),
+            avatarImageView.leadingAnchor.constraint(
+                equalTo: contentView.leadingAnchor,
+                constant: Padding.AvatarImage.left
+            ),
+            avatarImageView.heightAnchor.constraint(equalToConstant: Padding.AvatarImage.height),
+            avatarImageView.widthAnchor.constraint(equalToConstant: Padding.AvatarImage.width),
+
+            emailBottomView.bottomAnchor.constraint(
+                equalTo: contentView.bottomAnchor
+            ),
+            emailBottomViewHeight,
+            emailBottomView.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentView.trailingAnchor
+            ),
+            emailBottomView.leadingAnchor.constraint(
+                equalTo: bubbleView.leadingAnchor
+            ),
+
+            bubbleView.topAnchor.constraint(equalTo: nameLabel.bottomAnchor),
+            bubbleView.bottomAnchor.constraint(
+                equalTo: emailBottomView.topAnchor,
+                constant: -Padding.BubbleView.bottom
+            ),
+            bubbleView.leadingAnchor.constraint(
+                equalTo: avatarImageView.trailingAnchor,
+                constant: Padding.BubbleView.left
+            ),
+            bubbleView.trailingAnchor.constraint(
+                lessThanOrEqualTo: contentView.trailingAnchor,
+                constant: -Padding.BubbleView.right
+            ),
+
+            replyView.topAnchor.constraint(
+                equalTo: bubbleView.topAnchor,
+                constant: Padding.ReplyView.top
+            ),
+            replyView.heightAnchor.constraintEqualToAnchor(
+                constant: 0,
+                identifier: ConstraintIdentifier.replyViewHeightIdentifier
+            ),
+            replyView.leadingAnchor.constraint(
+                equalTo: bubbleView.leadingAnchor,
+                constant: Padding.ReplyView.left
+            ),
+            replyView.trailingAnchor.constraint(
+                equalTo: bubbleView.trailingAnchor,
+                constant: -Padding.ReplyView.right
+            ),
+
+            previewImageView.topAnchor.constraint(
+                equalTo: replyView.topAnchor,
+                constant: Padding.PreviewImageView.top
+            ),
+            previewImageView.trailingAnchor.constraint(
+                lessThanOrEqualTo: replyView.trailingAnchor,
+                constant: -Padding.PreviewImageView.right
+            ),
+            previewImageView.heightAnchor.constraintEqualToAnchor(
+                constant: 0,
+                identifier: ConstraintIdentifier.PreviewImage.height
+            ),
+            previewImageView.widthAnchor.constraintEqualToAnchor(
+                constant: 0,
+                identifier: ConstraintIdentifier.PreviewImage.width
+            ),
+
+            replyNameLabel.leadingAnchor.constraint(equalTo: replyView.leadingAnchor),
+            replyNameLabel.topAnchor.constraint(equalTo: replyView.topAnchor),
+            replyNameLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: previewImageView.leadingAnchor,
+                constant: -Padding.ReplyNameLabel.right
+            ),
+            replyNameLabel.heightAnchor.constraintEqualToAnchor(
+                constant: 0,
+                identifier: ConstraintIdentifier.ReplyNameLabel.height
+            ),
+
+            replyMessageLabel.leadingAnchor.constraint(equalTo: replyView.leadingAnchor),
+            replyMessageLabel.topAnchor.constraint(
+                equalTo: replyNameLabel.bottomAnchor,
+                constant: Padding.ReplyMessageLabel.top
+            ),
+            replyMessageLabel.trailingAnchor.constraint(
+                lessThanOrEqualTo: previewImageView.leadingAnchor,
+                constant: -Padding.ReplyMessageLabel.right
+            ),
+            replyMessageLabel.heightAnchor.constraintEqualToAnchor(
+                constant: 0,
+                identifier: ConstraintIdentifier.ReplyMessageLabel.height
+            ),
+            iframeView.topAnchor.constraint(equalTo: bubbleView.topAnchor),
+            iframeView.bottomAnchor.constraint(equalTo: bubbleView.bottomAnchor),
+            iframeView.trailingAnchor.constraint(equalTo: bubbleView.trailingAnchor),
+            iframeView.leadingAnchor.constraint(equalTo: bubbleView.leadingAnchor),
+            iframeWidth,
+            emailTopView.topAnchor.constraint(
+                equalTo: replyView.bottomAnchor,
+                constant: Padding.MessageView.top
+            ),
+            emailTopView.trailingAnchor.constraint(
+                equalTo: bubbleView.trailingAnchor,
+                constant: -ALKMessageStyle.receivedBubble.widthPadding
+            ),
+            emailTopView.leadingAnchor.constraint(
+                equalTo: bubbleView.leadingAnchor,
+                constant: ALKFriendMessageCell.bubbleViewLeftPadding
+            ),
+            emailTopHeight,
+
+            messageView.topAnchor.constraint(
+                equalTo: emailTopView.bottomAnchor
+            ),
+            messageView.trailingAnchor.constraint(
+                equalTo: bubbleView.trailingAnchor,
+                constant: -ALKMessageStyle.receivedBubble.widthPadding
+            ),
+            messageView.leadingAnchor.constraint(
+                equalTo: bubbleView.leadingAnchor,
+                constant: ALKFriendMessageCell.bubbleViewLeftPadding
+            ),
+
+            operationLineView.topAnchor.constraint(equalTo: messageView.bottomAnchor, constant: Padding.OperationLineView.top),
+            operationLineView.leadingAnchor.constraint(equalTo: messageView.leadingAnchor),
+            operationLineView.trailingAnchor.constraint(equalTo: messageView.trailingAnchor),
+            operationLineView.heightAnchor.constraint(equalToConstant: Padding.OperationLineView.height),
+
+            sourceLabel.topAnchor.constraint(equalTo: operationLineView.bottomAnchor, constant: Padding.SourceLableView.top),
+            sourceLabel.leadingAnchor.constraint(equalTo: messageView.leadingAnchor),
+            sourceLabel.trailingAnchor.constraint(equalTo: messageView.trailingAnchor),
+            
+            urlStackView.topAnchor.constraint(equalTo: sourceLabel.bottomAnchor, constant: Padding.SourceURLView.top),
+            urlStackView.leadingAnchor.constraint(equalTo: messageView.leadingAnchor),
+            urlStackView.trailingAnchor.constraint(equalTo: messageView.trailingAnchor),
+            
+            urlStackView.bottomAnchor.constraint(
+                equalTo: bubbleView.bottomAnchor,
+                constant: -Padding.MessageView.bottom
+            ),
+
+            
+            timeLabel.leadingAnchor.constraint(
+                equalTo: bubbleView.trailingAnchor,
+                constant: Padding.TimeLabel.left
+            ),
+            timeLabel.bottomAnchor.constraint(
+                equalTo: bubbleView.bottomAnchor,
+                constant: Padding.TimeLabel.bottom
+            ),
+        ])
+
+        let linktapGesture = UITapGestureRecognizer(target: self, action: #selector(viewEmailTappedAction))
+        emailBottomView.emailLinkLabel.addGestureRecognizer(linktapGesture)
+        nameLabel.isHidden = KMCellConfiguration.hideSenderName
+    }
+    
+    
+    override func setupStyle() {
+        super.setupStyle()
+
+        nameLabel.setStyle(ALKMessageStyle.displayName)
+        messageView.setStyle(ALKMessageStyle.receivedMessage)
+        bubbleView.setStyle(ALKMessageStyle.receivedBubble, isReceiverSide: true)
+    }
+
+    override func update(viewModel: ALKMessageViewModel) {
+        super.update(
+            viewModel: viewModel,
+            messageStyle: ALKMessageStyle.receivedMessage,
+            mentionStyle: ALKMessageStyle.receivedMention
+        )
+
+        if viewModel.isReplyMessage {
+            guard
+                let metadata = viewModel.metadata,
+                let replyId = metadata[AL_MESSAGE_REPLY_KEY] as? String,
+                let actualMessage = getMessageFor(key: replyId)
+            else { return }
+            showReplyView(true)
+            if actualMessage.messageType == .text || actualMessage.messageType == .html {
+                previewImageView.constraint(withIdentifier: ConstraintIdentifier.PreviewImage.height)?.constant = 0
+            } else {
+                previewImageView.constraint(withIdentifier: ConstraintIdentifier.PreviewImage.width)?.constant = Padding.PreviewImageView.width
+            }
+        } else {
+            showReplyView(false)
+        }
+
+        let placeHolder = UIImage(named: "placeholder", in: Bundle.km, compatibleWith: nil)
+        if let url = viewModel.avatarURL {
+            let resource = Kingfisher.ImageResource(downloadURL: url, cacheKey: url.absoluteString)
+            avatarImageView.kf.setImage(with: resource, placeholder: placeHolder)
+        } else {
+            avatarImageView.image = placeHolder
+        }
+        sourceLabel.text = localizedString(forKey: "Source",
+                                           withDefaultValue: SystemMessage.LabelName.Source,
+                                           fileName: localizedStringFileName)
+        nameLabel.text = viewModel.displayName
+        var urls = [""]
+        
+        if let messageMetadata = viewModel.metadata, let metadataValue = messageMetadata["sourceURLs"] as? [String] {
+            urls = metadataValue
+        }
+        urlStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        for url in urls {
+            let linkLabel = UILabel()
+            linkLabel.textColor = .blue
+            linkLabel.font = UIFont.systemFont(ofSize: 14)
+            linkLabel.text = url
+            linkLabel.isUserInteractionEnabled = true
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(linkLabelTapped(_:)))
+            linkLabel.addGestureRecognizer(tapGesture)
+            urlStackView.addArrangedSubview(linkLabel)
+        }
+    }
+
+    @objc private func linkLabelTapped(_ sender: UITapGestureRecognizer) {
+        guard let label = sender.view as? UILabel, let urlString = label.text, let url = URL(string: urlString) else { return }
+        UIApplication.shared.open(url)
+    }
+    
+    class func rowHeigh(
+        viewModel: ALKMessageViewModel,
+        width: CGFloat,
+        displayNames: ((Set<String>) -> ([String: String]?))?
+    ) -> CGFloat {
+        let minimumHeight = Padding.AvatarImage.top + Padding.AvatarImage.height + 5
+        /// Calculating available width for messageView
+        let leftSpacing = Padding.AvatarImage.left + Padding.AvatarImage.width + Padding.BubbleView.left + bubbleViewLeftPadding
+        let rightSpacing = Padding.BubbleView.right + ALKMessageStyle.receivedBubble.widthPadding
+        let messageWidth = width - (leftSpacing + rightSpacing)
+        
+        /// Calculating messageHeight
+        let messageHeight = super
+            .messageHeight(
+                viewModel: viewModel,
+                width: messageWidth,
+                font: ALKMessageStyle.receivedMessage.font,
+                mentionStyle: ALKMessageStyle.receivedMention,
+                displayNames: displayNames
+            )
+        
+        /// For calculating the height according to the number of urls
+        var urlCount = 0
+        if let messageMetadata = viewModel.metadata, let metadataValue = messageMetadata["sourceURLs"] as? [String] {
+            urlCount = metadataValue.count
+        }
+        
+        let heightPadding = Padding.NameLabel.top + Padding.NameLabel.height + Padding.ReplyView.top + Padding.MessageView.top + Padding.MessageView.bottom + Padding.BubbleView.bottom + Padding.SourceView.height +  (CGFloat(urlCount) * Padding.URLView.height)
+        
+        let totalHeight = max(messageHeight + heightPadding, minimumHeight)
+        
+        guard let metadata = viewModel.metadata,
+              metadata[AL_MESSAGE_REPLY_KEY] as? String != nil
+        else {
+            return totalHeight
+        }
+        return totalHeight + Padding.ReplyView.height
+    }
+
+    @objc private func avatarTappedAction() {
+        avatarTapped?()
+    }
+
+    @objc private func viewEmailTappedAction() {
+        let text = localizedString(forKey: "EmailWebViewTitle", withDefaultValue: SystemMessage.NavbarTitle.emailWebViewTitle, fileName: localizedStringFileName)
+
+        let emailWebViewController = ALKWebViewController(htmlString: viewModel?.message ?? "", url: nil, title: text)
+        let pushAssist = ALPushAssist()
+        pushAssist.topViewController.navigationController?.pushViewController(emailWebViewController, animated: true)
+    }
+
+    // MARK: - ChatMenuCell
+
+    override func menuWillShow(_ sender: Any) {
+        super.menuWillShow(sender)
+        if ALKMessageStyle.receivedBubble.style == .edge {
+            bubbleView.image = bubbleView.imageBubble(
+                for: ALKMessageStyle.receivedBubble.style,
+                isReceiverSide: true,
+                showHangOverImage: true
+            )
+        }
+    }
+
+    override func menuWillHide(_ sender: Any) {
+        super.menuWillHide(sender)
+        if ALKMessageStyle.receivedBubble.style == .edge {
+            bubbleView.image = bubbleView.imageBubble(
+                for: ALKMessageStyle.receivedBubble.style,
+                isReceiverSide: true,
+                showHangOverImage: false
+            )
+        }
+    }
+
+    private func showReplyView(_ show: Bool) {
+        replyView
+            .constraint(withIdentifier: ConstraintIdentifier.replyViewHeightIdentifier)?
+            .constant = show ? Padding.ReplyView.height : 0
+        replyNameLabel
+            .constraint(withIdentifier: ConstraintIdentifier.ReplyNameLabel.height)?
+            .constant = show ? Padding.ReplyNameLabel.height : 0
+        replyMessageLabel
+            .constraint(withIdentifier: ConstraintIdentifier.ReplyMessageLabel.height)?
+            .constant = show ? Padding.ReplyMessageLabel.height : 0
+        previewImageView
+            .constraint(withIdentifier: ConstraintIdentifier.PreviewImage.height)?
+            .constant = show ? Padding.PreviewImageView.height : 0
+        previewImageView
+            .constraint(withIdentifier: ConstraintIdentifier.PreviewImage.width)?
+            .constant = show ? Padding.PreviewImageView.width : 0
+
+        replyView.isHidden = !show
+        replyNameLabel.isHidden = !show
+        replyMessageLabel.isHidden = !show
+        previewImageView.isHidden = !show
+    }
+}


### PR DESCRIPTION
## Summary
- Added a new view for Source URL.

## Expected Data In Metadata
```
"sourceURLs" = ["https://dashboard.kommunicate.io", "https://docs.kommunicate.io"]
```

## Image 
### SDK
<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/1c6e5492-e6b9-416a-96fe-731e5002005c' height = 400/> 

### Agent App
<img src = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/318354cb-701f-4919-bfe5-24bfa3ed6bfd' height = 400/> 


