### PR TITLE
[CM-1121] Delete message with sync - iOS Agent App and SDK

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -533,7 +533,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
         contentOffsetDictionary = [NSObject: AnyObject]()
         print("id: ", viewModel.messageModels.first?.contactId as Any)
-        viewModel.removeAlreadyDeletedMessageFromConversation()
     }
 
     override open func viewDidAppear(_: Bool) {}
@@ -3006,7 +3005,6 @@ extension ALKConversationViewController: ALMQTTConversationDelegate {
     }
     
     public func removeMessageFromConversation(message: ALMessage) {
-        print("remove message conversation")
         viewModel.removeMessageFromTheConversation(message: message)
         tableView.reloadData()
     }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1707,6 +1707,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             }
             let models = messages.map { ($0 as! ALMessage).messageModel }
             self.messageModels.insert(contentsOf: models, at: 0)
+            self.removeAlreadyDeletedMessageFromConversation()
             self.removeMessageForHidePostCTA(messages: models)
             if isFirstTime {
                 self.membersInGroup { members in
@@ -1857,6 +1858,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 self.alMessageWrapper.getUpdatedMessageArray().insert(newMessages, at: 0)
                 self.alMessages.insert(mesg, at: 0)
                 self.messageModels.insert(mesg.messageModel, at: 0)
+                self.removeAlreadyDeletedMessageFromConversation()
                 self.removeMessageForHidePostCTA(messages: [mesg.messageModel])
             }
             self.delegate?.loadingFinished(error: nil)

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1373,6 +1373,25 @@ open class ALKConversationViewModel: NSObject, Localizable {
             self.delegate?.updateDisplay(contact: contact, channel: nil)
         })
     }
+    
+    func removeAlreadyDeletedMessageFromConversation() {
+        for message in alMessages {
+            if let metadata = message.metadata, let deleteGroupMessageForAll = metadata["AL_DELETE_GROUP_MESSAGE_FOR_ALL"] as? String, deleteGroupMessageForAll == "true" {
+                removeMessageFromTheConversation(message: message)
+            }
+        }
+    }
+    
+    func removeMessageFromTheConversation(message: ALMessage) {
+        if let index = messageModels.firstIndex(where: { $0.identifier == message.identifier }) {
+            messageModels.remove(at: index)
+        }
+        if let index = alMessages.firstIndex(where: { $0.identifier == message.identifier }) {
+            alMessages.remove(at: index)
+        }
+        let messageService = ALMessageDBService()
+        messageService.deleteMessage(byKey: message.identifier)
+    }
 
     func currentConversationProfile(completion: @escaping (ALKConversationProfile?) -> Void) {
         if channelKey != nil {
@@ -1457,6 +1476,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
             } else {
                 self.messageModels = self.modelsToBeAddedAfterDelay
             }
+            self.removeAlreadyDeletedMessageFromConversation()
             self.removeMessageForHidePostCTA(messages: self.messageModels)
             self.membersInGroup { members in
                 self.groupMembers = members


### PR DESCRIPTION
## Summary
- Added a check for `AL_DELETE_GROUP_MESSAGE_FOR_ALL` to remove conversation from DB.
- Added a notification for message metadata update and a check for Message Delete.
- Deleting the message from local DB as well for remove the chance of indexing error in Message Table.

## Video

https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/assets/139110221/81c086ad-c5a9-4f87-ae3d-7d0fefcb884a

