### PR TITLE
[CM-2111] Crash : closure #1 in ALKConversationViewController.configureChatBar() | iOS Agent App

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -873,29 +873,16 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     public func configureChatBar() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            self.chatBar.setDefaultText(self.viewModel.prefilledMessage ?? "")
-            
-            if ALApplozicSettings.isAgentAppConfigurationEnabled(),
-                ALUserDefaultsHandler.isTeamModeEnabled(),
-               let teamID = ALUserDefaultsHandler.getAssignedTeamIds(),
-               let teamIDArray = teamID as? [String],
-               let metadata = ALChannelService().getChannelByKey(self.viewModel.channelKey).metadata,
-               let newTeamID = metadata["KM_TEAM_ID"] as? String,
-               !teamIDArray.contains(newTeamID) {
-                
-                self.isChatBarResticted = true
-                self.chatBar.textView.text = "You are restricted to type or send any message as you are no longer part of this conversation."
-                return
-            }
-            
-            if self.viewModel.isOpenGroup {
-                self.chatBar.updateMediaViewVisibility(hide: true)
-                self.chatBar.hideMicButton()
-            } else {
-                self.chatBar.updateMediaViewVisibility()
-            }
+        self.chatBar.setDefaultText(self.viewModel.prefilledMessage ?? "")
+        if self.viewModel.isOpenGroup {
+            self.chatBar.updateMediaViewVisibility(hide: true)
+            self.chatBar.hideMicButton()
+        } else {
+            self.chatBar.updateMediaViewVisibility()
+        }
+        if ALApplozicSettings.isAgentAppConfigurationEnabled(),
+            ALUserDefaultsHandler.isTeamModeEnabled() {
+            self.checkRestrictedMesssaging()
         }
     }
 


### PR DESCRIPTION
## Summary
- Updated the code of configure chat bar code.
- Moved the check for restricted conversation bellow the other checks. 
- Used the existing function for checking the restrictions.