### PR TITLE
[CM-1836] Placeholder is getting refreshed on Bot delay| iOS SDK 

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2563,13 +2563,14 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             return
         }
         viewModel.markConversationRead()
-        var lastMessage = viewModel.messageModels.last
-        guard let lastMessage = lastMessage,
-              let placeholder = lastMessage.getKmField()?.placeholder
-        else {
-            return
+        if let lastALMessage = viewModel.alMessages.last?.autoSuggestionData,
+           let data = convertToDictionary(text: lastALMessage),
+           let placeholderValue = data["placeholder"] as? String {
+            chatBar.placeHolder.text = placeholderValue
+        } else if let lastMessage = viewModel.messageModels.last,
+                  let placeholder = lastMessage.getKmField()?.placeholder {
+            chatBar.placeHolder.text = placeholder
         }
-        chatBar.placeHolder.text = placeholder
     }
 
     public func messageSent(at indexPath: IndexPath) {


### PR DESCRIPTION
## Summary
- Added a placeholder identification check for autosuggestion message and adding the placeholder text on refresh of viewController.

## Video (Before - After)


https://github.com/user-attachments/assets/5c51c919-900d-4c9b-8f6d-f3d0ce604e6c


https://github.com/user-attachments/assets/41770b56-0804-4c60-a542-4ba30dd15864


