### PR TITLE
[CM-2145] Source URL UI and Flow Update | iOS SDK

### DIFF
--- a/Sources/Views/KMLabelWithIconView.swift
+++ b/Sources/Views/KMLabelWithIconView.swift
@@ -1,0 +1,71 @@
+//
+//  KMLabelWithIconView.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by Abhijeet Ranjan on 19/08/24.
+//
+
+import UIKit
+
+class KMLabelWithIconView: UIView {
+    var urlLink: String?
+
+    private let label: UILabel = {
+        let lbl = UILabel()
+        lbl.translatesAutoresizingMaskIntoConstraints = false
+        lbl.numberOfLines = 1
+        lbl.textColor = .gray
+        lbl.lineBreakMode = .byTruncatingTail
+        lbl.font = UIFont.systemFont(ofSize: 14)
+        return lbl
+    }()
+
+    private let iconImageView: UIImageView = {
+        let imgView = UIImageView()
+        imgView.image = UIImage(named: "link", in: Bundle.richMessageKit, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
+        imgView.tintColor = .black
+        imgView.translatesAutoresizingMaskIntoConstraints = false
+        imgView.contentMode = .scaleAspectFit
+        return imgView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        addSubview(label)
+        addSubview(iconImageView)
+        
+        NSLayoutConstraint.activate([
+            // Label Constraints
+            label.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            label.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            iconImageView.leadingAnchor.constraint(greaterThanOrEqualTo: label.trailingAnchor, constant: 8),
+            
+            // Icon Constraints
+            iconImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            iconImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 13),
+            iconImageView.heightAnchor.constraint(equalToConstant: 13),
+            
+            // Height Constraint
+            self.heightAnchor.constraint(equalToConstant: 16),
+            self.widthAnchor.constraint(equalToConstant: 250),
+        ])
+    }
+
+    func configure(withText text: String, withURL url: String) {
+        let attributedString = NSMutableAttributedString(string: text)
+        attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: NSRange(location: 0, length: text.count))
+
+        label.attributedText = attributedString
+        self.urlLink = url
+    }
+}


### PR DESCRIPTION
## Summary
- Added Link Icon in the End of Each Source URL Text. 
- Added a Code to Check if the title is not present in recived payload then it will use that for Title other wise it will extract the data from the URL.
- Added a code to extract the last text of URL. (For eg. : if URL is "https://www.apple.com/in/iphone-15/" it will extract "iphone-15" ) 
- Updated the code to extract object from string.( For eg: The code will also work if data is like this
```
answerSource = "[{\"name\":\"Kommunicate\",\"url\":\"https://dashboard.kommunicate.io/conversations/104283232\"},{\"name\":null,\"url\":\"https://dashboard.kommunicate.io/conversations/104243900\"},{\"name\":null,\"url\":\"https://dashboard.kommunicate.io\"},{\"name\":null,\"url\":\"https://dashboard.doc.io/\"}]"
```
- Added Underline in the title of URL.

## JSON Data
```
'answerSource' = [
    {
        "name": "Kommunicate",
        "url": "https://dashboard.kommunicate.io/conversations/104283232"
    },
    {
        "name": null,
        "url": "https://dashboard.kommunicate.io/conversations/104243900"
    },
    {
        "name": null,
        "url": "https://dashboard.kommunicate.io"
    },
    {
        "name": null,
        "url": "https://dashboard.doc.io/"
    }
]

```

## Image 

- Figma Image
<img src = 'https://github.com/user-attachments/assets/bc72e1eb-f16f-41e0-9fcb-18efdfd7f307' height = 260>

- iPhone 15 Pro Image (Normal Device)
<img src = 'https://github.com/user-attachments/assets/3fd78a5e-ca92-4f52-b4c2-081373833421' height = 360>

- iPhone SE (Small Device)
<img src = 'https://github.com/user-attachments/assets/b0b4d130-98ff-453c-bc48-29481b658fa0' height = 360>

- iPhone 15 Pro Max (Big Device)
<img src = 'https://github.com/user-attachments/assets/90b471c7-107f-4bdb-b0e2-03ec237eafc8' height = 360>

## Video

https://github.com/user-attachments/assets/60687f1c-b44f-4f4f-acf2-1647dccedd7f

