### PR TITLE
[CM-2070] Crash: ConversationListViewModel.updateTypingStatus(in:userId:status:) | iOS Agent App

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1207,9 +1207,9 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         hideMoreBar()
     }
     
-    public func showNewTypingLabel(status: Bool) {
+    public func showNewTypingLabel(status: Bool, isAgentApp: Bool = false) {
         if status {
-            self.viewModel.addTypingIndicatorMessage()
+            self.viewModel.addTypingIndicatorMessage(isAgentApp)
         } else {
             self.viewModel.removeTypingIndicatorMessage()
         }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1014,10 +1014,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
         uploadAudio(alMessage: alMessage, indexPath: IndexPath(row: 0, section: messageModels.count - 1))
     }
     
-    open func addTypingIndicatorMessage() {
+    open func addTypingIndicatorMessage(_ isAgentApp: Bool) {
         if alMessages.contains(where: { $0.contentType == Int16(ALMESSAGE_CONTENT_TYPING_INDICATOR) }) {
             self.removeTypingIndicatorMessage()
         }
+        guard !isAgentApp || alMessages.count != 0 else { return }
         addToWrapper(message: getTypingIndicatorMessage())
         self.delegate?.newMessagesAdded()
     }


### PR DESCRIPTION
## Summary
- Suspecting the crash occurs when the conversation screen is loading messages for the first time via the API, and the typing indicator is triggered simultaneously. An additional check is needed on the agent app side, as the typing indicator also appears for the welcome message on the SDK side.
