### PR TITLE
[CM-2195] Hide Chat Bar - Customization | iOS SDK

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -752,7 +752,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         typingNoticeView.bottomAnchor.constraint(equalTo: replyMessageView.topAnchor).isActive = true
         chatBar.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         chatBar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        if !isChatBarHidden {
+        if !isChatBarHidden && !configuration.chatBar.hideChatBarInConversaionScreen {
             bottomConstraint = chatBar.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             bottomConstraint?.isActive = true
         } else {
@@ -888,6 +888,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func prepareChatBar() {
+        if configuration.chatBar.hideChatBarInConversaionScreen {
+            chatBar.isHidden = true
+            return
+        }
         if configuration.chatBar.hideAttachmentOptionsForBotConvesations {
             chatBar.hideAllAttachmentButtonIcons(isHidden: viewModel.isBotHandelingConversation())
         }

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -452,8 +452,14 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
     
     open func updateAssigneeDetails() {
+        let isBotHandelingConversation = viewModel.isBotHandelingConversation()
         if configuration.chatBar.hideAttachmentOptionsForBotConvesations {
-            chatBar.hideAllAttachmentButtonIcons(isHidden: viewModel.isBotHandelingConversation())
+            chatBar.hideAllAttachmentButtonIcons(isHidden: isBotHandelingConversation)
+        }
+        if configuration.chatBar.hideChatBarForBotConvesations {
+            if chatBar.isHidden != isBotHandelingConversation {
+                isChatBarHidden = isBotHandelingConversation
+            }
         }
         self.viewModel.currentConversationProfile(completion: { profile in
             guard let profile = profile else { return }
@@ -752,7 +758,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         typingNoticeView.bottomAnchor.constraint(equalTo: replyMessageView.topAnchor).isActive = true
         chatBar.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         chatBar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        if !isChatBarHidden && !configuration.chatBar.hideChatBarInConversaionScreen {
+        if !isChatBarHidden {
             bottomConstraint = chatBar.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             bottomConstraint?.isActive = true
         } else {
@@ -888,12 +894,12 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     private func prepareChatBar() {
-        if configuration.chatBar.hideChatBarInConversaionScreen {
+        let isBotHandelingConversation = viewModel.isBotHandelingConversation()
+        if configuration.chatBar.hideChatBarForBotConvesations && isBotHandelingConversation {
             chatBar.isHidden = true
-            return
         }
         if configuration.chatBar.hideAttachmentOptionsForBotConvesations {
-            chatBar.hideAllAttachmentButtonIcons(isHidden: viewModel.isBotHandelingConversation())
+            chatBar.hideAllAttachmentButtonIcons(isHidden: isBotHandelingConversation)
         }
         // Update ChatBar's top view which contains send button and the text view.
         chatBar.grayView.backgroundColor = UIColor.kmDynamicColor(light: configuration.backgroundColor, dark: configuration.backgroundDarkColor)

--- a/Sources/Models/ALKChatBarConfiguration.swift
+++ b/Sources/Models/ALKChatBarConfiguration.swift
@@ -41,6 +41,9 @@ public struct ALKChatBarConfiguration {
     
     ///  If you set a color here then send button's tint color will be overridden by this color instead primary color.
     public var sendButtonTintColor: UIColor? = nil
+    
+    /// If you want to hide chat bar form the conversation list screen.
+    public var hideChatBarInConversaionScreen: Bool = false
 
     /// Set the maximum number of photos/videos that can be selected in the new photos UI.
     /// Maximum limit should be less than 30

--- a/Sources/Models/ALKChatBarConfiguration.swift
+++ b/Sources/Models/ALKChatBarConfiguration.swift
@@ -43,7 +43,7 @@ public struct ALKChatBarConfiguration {
     public var sendButtonTintColor: UIColor? = nil
     
     /// If you want to hide chat bar form the conversation list screen.
-    public var hideChatBarInConversaionScreen: Bool = false
+    public var hideChatBarForBotConvesations: Bool = false
 
     /// Set the maximum number of photos/videos that can be selected in the new photos UI.
     /// Maximum limit should be less than 30


### PR DESCRIPTION
## Summary
- Added a customisation to hide chat bar when bot is handling the conversation and enable chat bar when conversation is assigned to human.

## Customisation Code
- `Kommunicate.defaultConfiguration.chatBar.hideChatBarForBotConvesations = true`

## Video

https://github.com/user-attachments/assets/ed38888e-6694-4f58-9890-890004327066

