### PR TITLE
[CM-702] Conversation Section Colour Improvements | iOS Agent App

### DIFF
--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -40,15 +40,11 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         }
         cell.messageView.linkTextAttributes = [.foregroundColor: (message.isMyMessage) ? configuration.linkAttributeColorForSentMessage : configuration.linkAttributeColorForReceivedMessage,
                                                .underlineStyle: NSUnderlineStyle.single.rawValue]
-        if isAgentApp {
-            if message.isMyMessage {
-                cell.bubbleView.backgroundColor = UIColor(netHex: 0xE2F6FE)
+        if isAgentApp && !message.isMyMessage {
+            if (viewModel.conversationEndUserID == message.contactId) {
+                cell.bubbleView.backgroundColor = UIColor(netHex: 0xF5F5FA)
             } else {
-                if message.receiverId == viewModel.conversationEndUserID {
-                    cell.bubbleView.backgroundColor = UIColor(netHex: 0xF5F5FA)
-                } else {
-                    cell.bubbleView.backgroundColor = UIColor(netHex: 0xFFF3DA)
-                }
+                cell.bubbleView.backgroundColor = UIColor(netHex: 0xFFF3DA)
             }
         }
     }

--- a/Sources/Controllers/ALKConversationViewController+TableView.swift
+++ b/Sources/Controllers/ALKConversationViewController+TableView.swift
@@ -40,6 +40,17 @@ extension ALKConversationViewController: UITableViewDelegate, UITableViewDataSou
         }
         cell.messageView.linkTextAttributes = [.foregroundColor: (message.isMyMessage) ? configuration.linkAttributeColorForSentMessage : configuration.linkAttributeColorForReceivedMessage,
                                                .underlineStyle: NSUnderlineStyle.single.rawValue]
+        if isAgentApp {
+            if message.isMyMessage {
+                cell.bubbleView.backgroundColor = UIColor(netHex: 0xE2F6FE)
+            } else {
+                if message.receiverId == viewModel.conversationEndUserID {
+                    cell.bubbleView.backgroundColor = UIColor(netHex: 0xF5F5FA)
+                } else {
+                    cell.bubbleView.backgroundColor = UIColor(netHex: 0xFFF3DA)
+                }
+            }
+        }
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -526,9 +526,6 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
         viewModel.delegate = self
         isAgentApp = ALApplozicSettings.isAgentAppConfigurationEnabled()
-        if isAgentApp {
-            viewModel.getConversationEndUserID()
-        }
         refreshViewController()
 //        setupConstraints()
         

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -34,6 +34,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     /// Make this false if you want to use custom list view controller
     public var individualLaunch = true
 
+    public var isAgentApp = false
+    
     public lazy var chatBar = ALKChatBar(frame: CGRect.zero, configuration: self.configuration)
     public lazy var autocompleteManager: KMAutoCompleteManager = {
         let manager = KMAutoCompleteManager(
@@ -523,6 +525,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
         }
 
         viewModel.delegate = self
+        isAgentApp = ALApplozicSettings.isAgentAppConfigurationEnabled()
+        if isAgentApp {
+            viewModel.getConversationEndUserID()
+        }
         refreshViewController()
 //        setupConstraints()
         

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -93,6 +93,8 @@ open class ALKConversationViewModel: NSObject, Localizable {
     }
 
     open var messageModels: [ALKMessageModel] = []
+    
+    open var conversationEndUserID:  String = ""
 
     open var richMessages: [String: Any] = [:]
 
@@ -1495,6 +1497,18 @@ open class ALKConversationViewModel: NSObject, Localizable {
     /*
         Since we are getting the welcome message from Api Call, we are using this method to Show Typing Delay Indicator for Welcome Messsages
      */
+    
+    public func getConversationEndUserID() {
+        self.membersInGroup { members in
+            guard let members = members else { return }
+            for member in members {
+                if member.roleType == 3 {
+                    guard let userId = member.userId else { return }
+                    self.conversationEndUserID = userId
+                }
+            }
+        }
+    }
     
     func getLastSentMessage() -> ALMessage? {
         for message in alMessages.reversed() {


### PR DESCRIPTION
## Summary
- Added a check to identify the End User UserId. Used to identify the message received from where. This is required only for agent app for that added a check to only call the function when the agent app is enabled.
- Added colour for received message from bot or agent, End User or sent Message.


## Images 

<img src = 'https://github.com/user-attachments/assets/17769087-36e2-4ce0-949a-a938ae7c5075' height = 500/>


