### PR TITLE
[CM-2232] Zendesk Plugin Removal | iOS SDK

### DIFF
--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -18,12 +18,16 @@ Pod::Spec.new do |s|
     richMessage.resources = 'RichMessageKit/**/*{xcassets}'
   end
 
+  s.subspec 'Zendesk' do |zendesk|
+    zendesk.dependency 'ZendeskChatProvidersSDK', '~> 5.0.0'
+  end
+
+
   s.subspec 'Complete' do |complete|
     complete.source_files = 'Sources/**/*.swift'
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
     complete.dependency 'Kingfisher', '~> 7.6.2'
     complete.dependency 'SwipeCellKit', '~> 2.7.1'
-    complete.dependency 'ZendeskChatProvidersSDK',  '~> 5.0.0'
     complete.dependency 'iOSDropDown'
     complete.dependency 'KommunicateCore-iOS-SDK',  '1.2.3'
     complete.dependency 'KommunicateChatUI-iOS-SDK/RichMessageKit'

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -467,20 +467,21 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             guard let profile = profile else { return }
             self.navigationBar.updateView(profile: profile)
         })
+        #if canImport(ChatProvidersSDK)
+            guard KMZendeskChatHandler.shared.isZendeskEnabled(),
+                  let channel = ALChannelService().getChannelByKey(viewModel.channelKey),
+                  isZendeskConversation(channel: channel),
+                  !channel.isClosedConversation,
+                  let assigneeUserId = channel.assigneeUserId,
+                  let assignee = ALContactService().loadContact(byKey: "userId", value: assigneeUserId),
+                  let roleType = assignee.roleType as? UInt32,
+                  roleType == AL_APPLICATION_WEB_ADMIN.rawValue,
+                  let channelKeyString = viewModel.channelKey?.stringValue else {
+                return
+            }
         
-        guard KMZendeskChatHandler.shared.isZendeskEnabled(),
-              let channel = ALChannelService().getChannelByKey(viewModel.channelKey),
-              isZendeskConversation(channel: channel),
-              !channel.isClosedConversation,
-              let assigneeUserId = channel.assigneeUserId,
-              let assignee = ALContactService().loadContact(byKey: "userId", value: assigneeUserId),
-              let roleType = assignee.roleType as? UInt32,
-              roleType == AL_APPLICATION_WEB_ADMIN.rawValue,
-              let channelKeyString = viewModel.channelKey?.stringValue else {
-            return
-        }
-        
-        KMZendeskChatHandler.shared.handedOffToAgent(groupId: channelKeyString, happendNow: true)
+            KMZendeskChatHandler.shared.handedOffToAgent(groupId: channelKeyString, happendNow: true)
+        #endif
     }
     
     open func updateAssigneeOnlineStatus(userId: String){}

--- a/Sources/Utilities/KMZendeskChatHandler.swift
+++ b/Sources/Utilities/KMZendeskChatHandler.swift
@@ -6,8 +6,11 @@
 //
 
 import Foundation
-import ChatProvidersSDK
 import KommunicateCore_iOS_SDK
+
+#if canImport(ChatProvidersSDK)
+    import ChatProvidersSDK
+#endif
 
 struct KommunicateURL {
     static let attachmentURL = "https://chat.kommunicate.io/rest/ws/attachment/"
@@ -29,6 +32,7 @@ public protocol KMZendeskChatProtocol {
     func setGroupId(_ groupId: String)
 }
 // swiftlint:disable type_body_length
+#if canImport(ChatProvidersSDK)
 public class KMZendeskChatHandler : NSObject, JWTAuthenticator, KMZendeskChatProtocol {
     public static let shared = KMZendeskChatHandler()
     var groupId: String = ""
@@ -548,3 +552,4 @@ public class KMZendeskChatHandler : NSObject, JWTAuthenticator, KMZendeskChatPro
         return ["name":attachment.name, "mime_type": attachment.mimeType, "size": attachment.size, "url": attachment.url]
     }
 }
+#endif

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -809,9 +809,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 NSLog("No errors while sending the message in open group")
                 self.showTypingIndicatorAfterMessageSent()
                 ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.messageSend, data: ["message":alMessage])
-                if KMZendeskChatHandler.shared.isZendeskEnabled()  {
-                    KMZendeskChatHandler.shared.sendMessage(message: alMessage)
-                }
+                #if canImport(ChatProvidersSDK)
+                    if KMZendeskChatHandler.shared.isZendeskEnabled()  {
+                        KMZendeskChatHandler.shared.sendMessage(message: alMessage)
+                    }
+                #endif
                 guard !alMessage.isHiddenMessage() else {return}
                 alMessage.status = NSNumber(integerLiteral: Int(SENT.rawValue))
                 self.messageModels[indexPath.section] = alMessage.messageModel
@@ -824,9 +826,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
                 NSLog("No errors while sending the message")
                 self.showTypingIndicatorAfterMessageSent()
                 ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.messageSend, data: ["message":alMessage])
-                if KMZendeskChatHandler.shared.isZendeskEnabled()  {
-                    KMZendeskChatHandler.shared.sendMessage(message: alMessage)
-                }
+                #if canImport(ChatProvidersSDK)
+                    if KMZendeskChatHandler.shared.isZendeskEnabled()  {
+                        KMZendeskChatHandler.shared.sendMessage(message: alMessage)
+                    }
+                #endif
                 guard !alMessage.isHiddenMessage() else {return}
                 alMessage.status = NSNumber(integerLiteral: Int(SENT.rawValue))
                 self.messageModels[indexPath.section] = alMessage.messageModel
@@ -2068,9 +2072,11 @@ open class ALKConversationViewModel: NSObject, Localizable {
         ALMessageService.sharedInstance().sendMessages(alMessage, withCompletion: {
             message, error in
             let newMesg = alMessage
-            if KMZendeskChatHandler.shared.isZendeskEnabled() {
-                KMZendeskChatHandler.shared.sendAttachment(message: alMessage)
-            }
+            #if canImport(ChatProvidersSDK)
+                if KMZendeskChatHandler.shared.isZendeskEnabled() {
+                    KMZendeskChatHandler.shared.sendAttachment(message: alMessage)
+                }
+            #endif
             NSLog("message is: ", newMesg.key)
             NSLog("Message sent: \(String(describing: message)), \(String(describing: error))")
             if error == nil {


### PR DESCRIPTION
## Summary
- Moved Zendesk Plugin to optional State. 
- For Including Zendesk SDK need to add it like 'Kommunciate/Zendesk'
- Zendesk Code in SDK is optional until the package is included it will not be accessible.

## Pod File Reference 

- With Zendesk 
```
use_frameworks!
platform :ios, '13.0'

target 'MyTargetName' do
  pod 'Kommunicate/Zendesk'
end
```

- Without Zendesk
```
use_frameworks!
platform :ios, '13.0'

target 'MyTargetName' do
  pod 'Kommunicate'
end
```