### PR TITLE
[CM-1752] Collect email on Away Mode | iOS SDK

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -84,6 +84,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     let registerUserClientService = ALRegisterUserClientService()
 
     var loadingIndicator = ALKLoadingIndicator(frame: .zero)
+    
+    public var collectEmailOnAwayMode: Bool = false
 
     /// See configuration.
     var isGroupDetailActionEnabled = true
@@ -485,6 +487,12 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
     
     open func updateAssigneeOnlineStatus(userId: String){}
+    
+    open func showEmailCollectionUI() {}
+    
+    open func showInvalidEmail() {}
+    
+    open func awayModeEmailUpdated() {}
     
     open func addMessagesToList(_ messageList: [Any]) {
         viewModel.addMessagesToList(messageList)
@@ -2234,6 +2242,15 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
 extension ALKConversationViewController: ALKConversationViewModelDelegate {
     
+    public func isEmailUpdatedforUser(status: Bool) {
+        if status {
+            collectEmailOnAwayMode = false
+            awayModeEmailUpdated()
+        } else {
+            showInvalidEmail()
+        }
+    }
+    
     public func showInvalidReplyAlert(kmField: KMField) {
         
         guard let validation = kmField.validation else {
@@ -2595,6 +2612,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
             reloadProcessedMessages(index: indexPath.section)
         }
         moveTableViewToBottom(indexPath: indexPath)
+        if collectEmailOnAwayMode {
+            showEmailCollectionUI()
+        }
     }
 
     public func updateDisplay(contact: ALContact?, channel: ALChannel?) {

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -494,6 +494,8 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     
     open func awayModeEmailUpdated() {}
     
+    open func awayModeEmailUpdatedSuccesfully() {}
+    
     open func addMessagesToList(_ messageList: [Any]) {
         viewModel.addMessagesToList(messageList)
     }
@@ -2242,13 +2244,18 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
 
 extension ALKConversationViewController: ALKConversationViewModelDelegate {
     
-    public func isEmailUpdatedforUser(status: Bool) {
+    public func isEmailSentForUpdatingUser(status: Bool) {
         if status {
             collectEmailOnAwayMode = false
             awayModeEmailUpdated()
         } else {
             showInvalidEmail()
         }
+    }
+    
+    public func emailUpdatedForUser() {
+        collectEmailOnAwayMode = false
+        awayModeEmailUpdatedSuccesfully()
     }
     
     public func showInvalidReplyAlert(kmField: KMField) {

--- a/Sources/Utilities/String+Extension.swift
+++ b/Sources/Utilities/String+Extension.swift
@@ -72,6 +72,13 @@ extension String {
 }
 
 extension String {
+    func isValidEmail() -> Bool {
+        let regex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
+        return NSPredicate(format: "SELF MATCHES %@", regex).evaluate(with: self)
+    }
+}
+
+extension String {
     var data: Data {
         return Data(utf8)
     }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -23,7 +23,8 @@ public protocol ALKConversationViewModelDelegate: AnyObject {
     func willSendMessage()
     func updateTyingStatus(status: Bool, userId: String)
     func showInvalidReplyAlert(kmField : KMField)
-    func isEmailUpdatedforUser(status: Bool)
+    func isEmailSentForUpdatingUser(status: Bool)
+    func emailUpdatedForUser()
 }
 
 // swiftlint:disable:next type_body_length
@@ -801,12 +802,12 @@ open class ALKConversationViewModel: NSObject, Localizable {
         
         if emailCollectionAwayModeEnabled {
             if(!message.isValidEmail()) {
-                delegate?.isEmailUpdatedforUser(status: false)
+                delegate?.isEmailSentForUpdatingUser(status: false)
                 return
             }
             emailCollectionAwayModeEnabled = false
             updateEmailFromCollectEmail(email: message)
-            delegate?.isEmailUpdatedforUser(status: true)
+            delegate?.isEmailSentForUpdatingUser(status: true)
         }
             
         var indexPath = IndexPath(row: 0, section: messageModels.count - 1)
@@ -863,6 +864,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         ALUserClientService().updateUser(nil, email: email, ofUser: nil) { theJson, error in
             if(error == nil){
                 print("User's email updated")
+                self.delegate?.emailUpdatedForUser()
             } else {
                 print("error occured while updating user's email \(String(describing: error?.localizedDescription))")
             }


### PR DESCRIPTION
## Summary
- Added the regex to verify the email is in correct format.
- Added the code to update email for user when passed is conversation while email collection is enabled (On Away Mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced email collection functionality, including a new property to manage email collection in away mode.
	- Added methods to display email collection UI and handle email validation.
	- Enhanced email validation process, allowing direct invocation on string instances.

- **Bug Fixes**
	- Improved email validation logic within the messaging workflow to ensure proper handling of email addresses.

- **Documentation**
	- Updated method signatures for clarity and improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->