### PR TITLE
[CM-1614] Thumbnail for the videos is not showing after reopening the conversation| iOS SDK

### DIFF
--- a/Sources/Views/ALKVideoCell.swift
+++ b/Sources/Views/ALKVideoCell.swift
@@ -265,12 +265,12 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
             playButton.isHidden = true
             progressView.isHidden = true
             loadThumbnail()
-        case .downloaded:
+        case let .downloaded(filePath):
             uploadButton.isHidden = true
             downloadButton.isHidden = true
             progressView.isHidden = true
             playButton.isHidden = false
-            loadThumbnail()
+            loadThumbnail(isDownloaded: true,filePath: filePath)
         case let .downloading(progress, _):
             // show progress bar
             print("downloading")
@@ -299,7 +299,7 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
         }
     }
 
-    func loadThumbnail() {
+    func loadThumbnail(isDownloaded : Bool = false, filePath : String? = nil) {
         guard let message = viewModel, let metadata = message.fileMetaInfo else {
             return
         }
@@ -309,9 +309,19 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
             return
         }
         /*
+            if Video is already Downloaded, then the Thumbnail will be directly fetched from file.
+         */
+        if isDownloaded, let filePath = filePath {
+            let docDirPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            let path = docDirPath.appendingPathComponent(filePath)
+            let fileUtills = ALKFileUtils()
+            photoView.image = fileUtills.getThumbnail(filePath: path) ?? placeHolderImage
+            return
+        }
+        /*
             if URL is exist on metadata, then it was upload by S3 Service. if not it was uploaded by Google
          */
-        if metadata.url == nil {
+        if metadata.url == nil && !message.isMyMessage {
             photoView.kf.setImage(with: message.thumbnailURL, placeholder: placeHolderImage)
             return
         }


### PR DESCRIPTION
## Summary
- Added the flow to use the downloaded video file to extract the thumbnail.
- Updated the code to identify Sent Video File to directly extract thumbnail.

## Image (Before - After)

<img src = 'https://github.com/user-attachments/assets/66ddcb1a-b2e7-479d-8bc6-e04f7ee77225' height = 360> <img src = 'https://github.com/user-attachments/assets/3fb71655-d0e9-49a9-93f0-6a2056af386b' height = 360>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced video state handling for improved thumbnail loading.
	- Thumbnails can now be loaded from a local file path if a video is downloaded.

- **Bug Fixes**
	- Improved logic for loading thumbnails based on download status. 

- **Documentation**
	- Updated comments for clarity on new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->