### PR TITLE
[CM-1564] Add .all in event list so every event will be included | iOS SDK

### DIFF
--- a/Sources/CustomEvent/ALKCustomEventHandler.swift
+++ b/Sources/CustomEvent/ALKCustomEventHandler.swift
@@ -105,4 +105,10 @@ public class ALKCustomEventHandler {
     public func unsubscribeEvents() {
         subscribedEvents.removeAll()
     }
+    
+    
+    /// This method is used to retrieve a list of all available events.
+    public func availableEvents() -> [KMCustomEvent] {
+        return KMCustomEvent.allEvents
+    }
 }

--- a/Sources/CustomEvent/KMCustomEvent.swift
+++ b/Sources/CustomEvent/KMCustomEvent.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-public enum KMCustomEvent: String {
+public enum KMCustomEvent: String, CaseIterable {
     case messageSend = "ON_MESSAGE_SEND"
     case faqClick = "ON_FAQ_CLICK"
     case newConversation = "ON_START_NEW_CONVERSATION_CLICK"
@@ -18,4 +18,8 @@ public enum KMCustomEvent: String {
     case messageReceive = "ON_MESSAGE_RECEIVE"
     case conversationInfoClick = "ON_CONVERSATION_INFO_CLICK"
     
+    
+    public static var allEvents: [KMCustomEvent] {
+        return Array(self.allCases)
+    }
 }


### PR DESCRIPTION
## Summary
- Added a function to share all the available events in `KMCustomEvent` with `allEvents`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to retrieve all available custom events
	- Enhanced `KMCustomEvent` enum with ability to list all event cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->