### PR TITLE
[CM-2310] Add waiting Queue UI in SDK | iOS

### DIFF
--- a/Sources/Controllers/ALKConversationListTableViewController.swift
+++ b/Sources/Controllers/ALKConversationListTableViewController.swift
@@ -57,7 +57,7 @@ public class ALKConversationListTableViewController: UITableViewController, Loca
     fileprivate var showSearch: Bool
     fileprivate var localizedStringFileName: String
     fileprivate var tapToDismiss: UITapGestureRecognizer!
-    fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.gray)
+    fileprivate let activityIndicator = UIActivityIndicatorView(style: UIActivityIndicatorView.Style.medium)
     fileprivate let searchController = UISearchController(searchResultsController: nil)
     fileprivate var searchActive: Bool = false
     fileprivate var searchFilteredChat: [Any] = []

--- a/Sources/Resources/ALKAssets.xcassets/Profile/Contents.json
+++ b/Sources/Resources/ALKAssets.xcassets/Profile/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Sources/Resources/ALKAssets.xcassets/Profile/watingQueueProfile.imageset/Contents.json
+++ b/Sources/Resources/ALKAssets.xcassets/Profile/watingQueueProfile.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "Frame 39.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Resources/ALKAssets.xcassets/Profile/watingQueueProfile.imageset/Frame 39.svg
+++ b/Sources/Resources/ALKAssets.xcassets/Profile/watingQueueProfile.imageset/Frame 39.svg
@@ -1,0 +1,6 @@
+<svg width="84" height="84" viewBox="0 0 84 84" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="42" cy="42" r="42" fill="#D9D9D9"/>
+<circle cx="4" cy="4" r="4" transform="matrix(-1 0 0 1 32 54)" fill="#F1F1F1"/>
+<circle cx="4" cy="4" r="4" transform="matrix(-1 0 0 1 46 54)" fill="#F1F1F1"/>
+<circle cx="4" cy="4" r="4" transform="matrix(-1 0 0 1 60 54)" fill="#F1F1F1"/>
+</svg>

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -20,6 +20,10 @@ enum ChannelMetadataKey {
     static let conversationSubject = "KM_CONVERSATION_SUBJECT"
 }
 
+public enum KMConversationStatus: String {
+    case waiting = "7"
+}
+
 let emailSourceType = 7
 
 extension ALMessage: ALKChatViewModelProtocol {
@@ -240,10 +244,11 @@ extension ALMessage: ALKChatViewModelProtocol {
         return tagsArray
     }
     
-    public var isWatingQueueConversation: Bool {
+    public var isWaitingQueueConversation: Bool {
+        guard let channelKey = channelKey else { return false }
         guard let channel = ALChannelService().getChannelByKey(channelKey),
               let conversationStatus = channel.metadata.value(forKey: AL_CHANNEL_CONVERSATION_STATUS) as? String,
-              conversationStatus == "7" else {
+              conversationStatus == KMConversationStatus.waiting.rawValue else {
             return false
         }
         return true

--- a/Sources/Utilities/ALMessage+Extension.swift
+++ b/Sources/Utilities/ALMessage+Extension.swift
@@ -239,6 +239,15 @@ extension ALMessage: ALKChatViewModelProtocol {
         }
         return tagsArray
     }
+    
+    public var isWatingQueueConversation: Bool {
+        guard let channel = ALChannelService().getChannelByKey(channelKey),
+              let conversationStatus = channel.metadata.value(forKey: AL_CHANNEL_CONVERSATION_STATUS) as? String,
+              conversationStatus == "7" else {
+            return false
+        }
+        return true
+    }
 }
 
 extension ALMessage {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -126,7 +126,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
         else {
             return false
         }
-        return conversationStatus == "7"
+        return conversationStatus == KMConversationStatus.waiting.rawValue
     }
     
     open var assignedTeamId: String? {

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -118,6 +118,28 @@ open class ALKConversationViewModel: NSObject, Localizable {
         return alchannel.type == 6
     }
     
+    open var isWaitingQueueConversation: Bool {
+        let alChannelService = ALChannelService()
+        guard let channelKey = channelKey,
+              let alchannel = alChannelService.getChannelByKey(channelKey),
+              let conversationStatus = alchannel.metadata[AL_CHANNEL_CONVERSATION_STATUS] as? String
+        else {
+            return false
+        }
+        return conversationStatus == "7"
+    }
+    
+    open var assignedTeamId: String? {
+        let alChannelService = ALChannelService()
+        guard let channelKey = channelKey,
+              let alchannel = alChannelService.getChannelByKey(channelKey),
+              let teamID = alchannel.metadata["KM_TEAM_ID"] as? String
+        else {
+            return nil
+        }
+        return teamID
+    }
+    
     // To get Conversation created time based on its first message.
     open var conversationCreatedTime: NSNumber? {
         if alMessages.isEmpty {

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -31,7 +31,7 @@ public protocol ALKChatViewModelProtocol {
     var messageMetadata: NSMutableDictionary? { get }
     var platformSource: String? { get }
     var assignedTags: [KMAssignedTags]? { get }
-    var isWatingQueueConversation: Bool { get }
+    var isWaitingQueueConversation: Bool { get }
 }
 
 extension ALKChatViewModelProtocol {
@@ -279,7 +279,7 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
     public func update(viewModel: ALKChatViewModelProtocol, identity _: ALKIdentityProtocol?, placeholder: UIImage? = nil) {
         self.viewModel = viewModel
         
-        if viewModel.isWatingQueueConversation {
+        if viewModel.isWaitingQueueConversation {
             avatarImageView.image = UIImage(named: "watingQueueProfile", in: Bundle.km, compatibleWith: nil)
             nameLabel.text = localizedString(forKey: LocalizationKey.waitingQueTitle, withDefaultValue: "In queue...", fileName:localizationFileName)
             messageLabel.text = ""

--- a/Sources/Views/ALKChatCell.swift
+++ b/Sources/Views/ALKChatCell.swift
@@ -31,6 +31,7 @@ public protocol ALKChatViewModelProtocol {
     var messageMetadata: NSMutableDictionary? { get }
     var platformSource: String? { get }
     var assignedTags: [KMAssignedTags]? { get }
+    var isWatingQueueConversation: Bool { get }
 }
 
 extension ALKChatViewModelProtocol {
@@ -103,6 +104,9 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
         case iconWidthIdentifier = "iconViewWidth"
     }
 
+    enum LocalizationKey {
+        static let waitingQueTitle = "waitingQueueTitle"
+    }
     enum Padding {
         enum Email {
             static let top: CGFloat = 4
@@ -274,47 +278,55 @@ public final class ALKChatCell: SwipeTableViewCell, Localizable {
 
     public func update(viewModel: ALKChatViewModelProtocol, identity _: ALKIdentityProtocol?, placeholder: UIImage? = nil) {
         self.viewModel = viewModel
-        let placeHolder = placeholderImage(placeholder, viewModel: viewModel)
         
-        if let avatarImage = viewModel.avatarImage {
-              if let imgStr = viewModel.avatarGroupImageUrl, let imgURL = URL(string: imgStr) {
-                let resource = Kingfisher.ImageResource(downloadURL: imgURL, cacheKey: imgStr)
-                avatarImageView.kf.setImage(with: resource, placeholder: avatarImage)
-              } else if let avatar = viewModel.avatar {
+        if viewModel.isWatingQueueConversation {
+            avatarImageView.image = UIImage(named: "watingQueueProfile", in: Bundle.km, compatibleWith: nil)
+            nameLabel.text = localizedString(forKey: LocalizationKey.waitingQueTitle, withDefaultValue: "In queue...", fileName:localizationFileName)
+            messageLabel.text = ""
+            attachmentImageView.image = nil
+        } else {
+            let placeHolder = placeholderImage(placeholder, viewModel: viewModel)
+            
+            if let avatarImage = viewModel.avatarImage {
+                if let imgStr = viewModel.avatarGroupImageUrl, let imgURL = URL(string: imgStr) {
+                    let resource = Kingfisher.ImageResource(downloadURL: imgURL, cacheKey: imgStr)
+                    avatarImageView.kf.setImage(with: resource, placeholder: avatarImage)
+                } else if let avatar = viewModel.avatar {
+                    let resource = Kingfisher.ImageResource(downloadURL: avatar, cacheKey: avatar.absoluteString)
+                    avatarImageView.kf.setImage(with: resource, placeholder: placeHolder)
+                } else {
+                    avatarImageView.image = placeHolder
+                }
+            } else if let avatar = viewModel.avatar {
                 let resource = Kingfisher.ImageResource(downloadURL: avatar, cacheKey: avatar.absoluteString)
                 avatarImageView.kf.setImage(with: resource, placeholder: placeHolder)
-              } else {
+            } else {
                 avatarImageView.image = placeHolder
-              }
-            } else if let avatar = viewModel.avatar {
-            let resource = Kingfisher.ImageResource(downloadURL: avatar, cacheKey: avatar.absoluteString)
-            avatarImageView.kf.setImage(with: resource, placeholder: placeHolder)
-        } else {
-            avatarImageView.image = placeHolder
+            }
+            
+            let name = viewModel.isGroupChat ? viewModel.groupName : viewModel.name
+            nameLabel.text = name
+            
+            let attrs: [NSAttributedString.Key: Any] = [
+                NSAttributedString.Key.font: messageLabel.font ?? Font.normal(size: 14.0).font(),
+                NSAttributedString.Key.foregroundColor: messageLabel.textColor ?? UIColor(netHex: 0x9B9B9B),
+            ]
+            
+            if let attributedText = viewModel
+                .attributedTextWithMentions(
+                    defaultAttributes: [:],
+                    mentionAttributes: attrs as [NSAttributedString.Key: Any],
+                    displayNames: displayNames
+                )
+            {
+                messageLabel.attributedText = attributedText
+            } else {
+                let lastMessage = viewModel.theLastMessage != nil ? localizedString(forKey: viewModel.theLastMessage!, withDefaultValue: viewModel.theLastMessage!, fileName:localizationFileName) :  ""
+                messageLabel.text = lastMessage
+            }
+            
+            updateAttchmentIcon(type: viewModel.messageType)
         }
-
-        let name = viewModel.isGroupChat ? viewModel.groupName : viewModel.name
-        nameLabel.text = name
-
-        let attrs: [NSAttributedString.Key: Any] = [
-            NSAttributedString.Key.font: messageLabel.font ?? Font.normal(size: 14.0).font(),
-            NSAttributedString.Key.foregroundColor: messageLabel.textColor ?? UIColor(netHex: 0x9B9B9B),
-        ]
-
-        if let attributedText = viewModel
-            .attributedTextWithMentions(
-                defaultAttributes: [:],
-                mentionAttributes: attrs as [NSAttributedString.Key: Any],
-                displayNames: displayNames
-            )
-         {
-            messageLabel.attributedText = attributedText
-        } else {
-            let lastMessage = viewModel.theLastMessage != nil ? localizedString(forKey: viewModel.theLastMessage!, withDefaultValue: viewModel.theLastMessage!, fileName:localizationFileName) :  ""
-            messageLabel.text = lastMessage
-        }
-        
-        updateAttchmentIcon(type: viewModel.messageType)
         
         muteIcon.isHidden = !isConversationMuted(viewModel: viewModel)
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for waiting queue conversations
	- Introduced new properties to track conversation status and assigned team

- **Style**
	- Updated activity indicator style from gray to medium

- **Chores**
	- Added new image asset for waiting queue profile
	- Minor JSON file formatting updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Images

<img src = 'https://github.com/user-attachments/assets/6b26ecde-7e4a-4a1f-8514-d0e6a60a5445' height = 360> <img src = 'https://github.com/user-attachments/assets/e655235c-2f4b-4682-a2b1-d395614ced98' height = 360>
