### PR TITLE
[CM-1829] AWS Encrypted titled docs while uploading | iOS SDK

### DIFF
--- a/Sources/Utilities/ALKFileUtils.swift
+++ b/Sources/Utilities/ALKFileUtils.swift
@@ -17,6 +17,20 @@ class ALKFileUtils: NSObject {
             }
             return (localPathName as NSString).lastPathComponent as String
         }
+        return removeFirstAWSEncrypted(from: fileName)
+    }
+    
+    /// This function removes the "AWS-ENCRYPTED-" prefix from a file name only if it's at the start and the remaining content has meaningful text before the file extension.
+    func removeFirstAWSEncrypted(from fileName: String) -> String {
+        let prefix = "AWS-ENCRYPTED-"
+        
+        if fileName.hasPrefix(prefix) {
+            let remaining = String(fileName.dropFirst(prefix.count))
+            if let dotIndex = remaining.firstIndex(of: "."), remaining.distance(from: remaining.startIndex, to: dotIndex) > 0 {
+                return remaining
+            }
+        }
+        
         return fileName
     }
 


### PR DESCRIPTION
## Summary
- Created a function that removes the "AWS-ENCRYPTED-" prefix from a file name only if it's at the start and the remaining content has meaningful text before the file extension.

## Image (Before- After)

<img src = 'https://github.com/user-attachments/assets/f93529d7-3ffd-43d2-b192-66f397b50050' height = 360> <img src = 'https://github.com/user-attachments/assets/eeba52e7-3a0d-440b-8da2-c562956c9e1e' height = 360>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to remove "AWS-ENCRYPTED-" prefix from file names
	- Enhanced file name processing to handle AWS-encrypted file names more effectively

<!-- end of auto-generated comment: release notes by coderabbit.ai -->