### PR TITLE
Patch Release / 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 The changelog for [KommunicateChatUI-iOS-SDK](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK). Also see the [releases](https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK/releases) on Github.
 
+## [1.4.1] 2025-02-14
+- Updated Kingfisher from 7.6.2 to 7.10.0 to align with Privacy Manifest requirements.
+
 ## [1.4.0] 2025-01-03
 - Added Waiting Queue UI and related functions.
 - Synchronized Chat UI configuration for Swift 6 support.

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -14,16 +14,16 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kingfisher (7.6.2)
-  - KommunicateChatUI-iOS-SDK (1.4.0):
-    - KommunicateChatUI-iOS-SDK/Complete (= 1.4.0)
-  - KommunicateChatUI-iOS-SDK/Complete (1.4.0):
+  - Kingfisher (7.10.2)
+  - KommunicateChatUI-iOS-SDK (1.4.1):
+    - KommunicateChatUI-iOS-SDK/Complete (= 1.4.1)
+  - KommunicateChatUI-iOS-SDK/Complete (1.4.1):
     - iOSDropDown
-    - Kingfisher (~> 7.6.2)
+    - Kingfisher (~> 7.10.0)
     - KommunicateChatUI-iOS-SDK/RichMessageKit
     - KommunicateCore-iOS-SDK (= 1.2.5)
     - SwipeCellKit (~> 2.7.1)
-  - KommunicateChatUI-iOS-SDK/RichMessageKit (1.4.0)
+  - KommunicateChatUI-iOS-SDK/RichMessageKit (1.4.1)
   - KommunicateCore-iOS-SDK (1.2.5)
   - Nimble (13.7.1):
     - CwlPreconditionTesting (~> 2.2.0)
@@ -75,8 +75,8 @@ SPEC CHECKSUMS:
   CwlPreconditionTesting: 67a0047dd4de4382b93442c0e3f25207f984f35a
   iOSDropDown: ce9daa584eaa5567cafc1b633e3cc7eb6d9cea42
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
-  KommunicateChatUI-iOS-SDK: 9bb58dc4b5ba0afe34ded7b7e39f67bd0f7c94e0
+  Kingfisher: 99edc495d3b7607e6425f0d6f6847b2abd6d716d
+  KommunicateChatUI-iOS-SDK: 19b316e766c57c091c0f08a9057fa19cf8b4f570
   KommunicateCore-iOS-SDK: 5dc0d852f3e49c37b33a808d73556cf683b2f6c0
   Nimble: 317d713c30c3336dd8571da1889f7ec3afc626e8
   Nimble-Snapshots: 240ea76ee8e52dfc1387b8d0d9bf1db3420cabbd

--- a/KommunicateChatUI-iOS-SDK.podspec
+++ b/KommunicateChatUI-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'KommunicateChatUI-iOS-SDK'
-  s.version = '1.4.0'
+  s.version = '1.4.1'
   s.license = { :type => "BSD 3-Clause", :file => "LICENSE" }
   s.summary = 'KommunicateChatUI-iOS-SDK Kit'
   s.homepage = 'https://github.com/Kommunicate-io/KommunicateChatUI-iOS-SDK'
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.subspec 'Complete' do |complete|
     complete.source_files = 'Sources/**/*.swift'
     complete.resources = 'Sources/**/*{lproj,storyboard,xib,xcassets,json}'
-    complete.dependency 'Kingfisher', '~> 7.6.2'
+    complete.dependency 'Kingfisher', '~> 7.10.0'
     complete.dependency 'SwipeCellKit', '~> 2.7.1'
     complete.dependency 'iOSDropDown'
     complete.dependency 'KommunicateCore-iOS-SDK',  '1.2.5'

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "af4be924ad984cf4d16f4ae4df424e79a443d435",
-          "version": "7.6.2"
+          "revision": "277f1ab2c6664b19b4a412e32b094b201e2d5757",
+          "version": "7.10.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "KommunicateCore_iOS_SDK", url: "https://github.com/Kommunicate-io/KommunicateCore-iOS-SDK.git", from: "1.2.5"),
-        .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", .exact("7.6.2")),
+        .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", .exact("7.10.0")),
         .package(name: "SwipeCellKit", url: "https://github.com/SwipeCellKit/SwipeCellKit.git", from: "2.7.1"),
         .package(name: "ZendeskChatProvidersSDK", url: "https://github.com/zendesk/chat_providers_sdk_ios",.exact("5.0.0")),
         .package(name: "iOSDropDown", url: "https://github.com/jriosdev/iOSDropDown.git", .upToNextMajor(from: "0.4.0"))


### PR DESCRIPTION
## Summary
- Updated Kingfisher from 7.6.2 to 7.10.0 to align with Privacy Manifest requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the KommunicateChatUI-iOS-SDK to version 1.4.1.
  - Updated a key dependency to ensure enhanced compliance with current privacy standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->