### PR TITLE
[CM-2338] Show Typing Indicator in Bot Messages till Bot Replies | iOS SDK

### DIFF
--- a/Sources/Utilities/ALKAppSettingsUserDefaults.swift
+++ b/Sources/Utilities/ALKAppSettingsUserDefaults.swift
@@ -207,7 +207,9 @@ public struct ALKAppSettingsUserDefaults {
 }
 
 /// `ALKAppSettings`class is used for creating a app settings details
-public class ALKAppSettings: NSObject, NSCoding {
+public class ALKAppSettings: NSObject, NSSecureCoding {
+    public static var supportsSecureCoding: Bool = true
+
     enum CoderKey {
         static let primaryColor = "primaryColor"
         static let showPoweredBy = "showPoweredBy"
@@ -220,7 +222,7 @@ public class ALKAppSettings: NSObject, NSCoding {
         static let defaultUploadOverrideUrl = "defaultUploadOverrideUrl"
         static let defaultUploadOverrideHeaders = "defaultUploadOverrideHeaders"
         static let csatRatingBase = "csatRatingBase"
-        
+        static let botTypingIndicatorInterval = "botTypingIndicatorInterval"
     }
 
     var primaryColor: String
@@ -237,6 +239,7 @@ public class ALKAppSettings: NSObject, NSCoding {
     public var defaultUploadOverrideUrl: String?
     public var defaultUploadOverrideHeaders: [String:String]?
     public var csatRatingBase: Int = 3
+    public var botTypingIndicatorInterval: Int = 0
 
     // MARK: - Public Initialization
 
@@ -256,6 +259,7 @@ public class ALKAppSettings: NSObject, NSCoding {
         defaultUploadOverrideUrl = coder.decodeObject(forKey: CoderKey.defaultUploadOverrideUrl) as? String
         defaultUploadOverrideHeaders = coder.decodeObject(forKey: CoderKey.defaultUploadOverrideHeaders) as? [String:String]
         csatRatingBase = coder.decodeInteger(forKey: CoderKey.csatRatingBase)
+        botTypingIndicatorInterval = coder.decodeInteger(forKey: CoderKey.botTypingIndicatorInterval)
     }
 
     // MARK: - Public methods
@@ -270,5 +274,6 @@ public class ALKAppSettings: NSObject, NSCoding {
         coder.encode(buttonPrimaryColor, forKey: CoderKey.buttonPrimaryColor)
         coder.encode(hidePostCTAEnabled, forKey: CoderKey.hidePostCTAEnabled)
         coder.encode(csatRatingBase, forKey: CoderKey.csatRatingBase)
+        coder.encode(botTypingIndicatorInterval, forKey: CoderKey.botTypingIndicatorInterval)
     }
 }

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -779,6 +779,30 @@ open class ALKConversationViewModel: NSObject, Localizable {
             updateMessageStatus(filteredList: newFilteredList, status: status)
         }
     }
+    
+    func showTypingIndicatorTillBotNewMessage() {
+        guard
+              let channel = ALChannelService().getChannelByKey(self.alMessages[0].groupId as NSNumber),
+              let assigneeUserId = channel.assigneeUserId,
+              let alContact = ALContactService().loadContact(byKey: "userId", value:  assigneeUserId),
+              alContact.roleType == NSNumber.init(value: AL_BOT.rawValue)
+        else { return }
+
+        let userDefaults = UserDefaults(suiteName: "group.kommunicate.sdk") ?? .standard
+        let botDelayTime = userDefaults.integer(forKey: "BOT_TYPING_INDICATOR_INTERVAL") / 1000
+        
+        guard botDelayTime > 0 else { return }
+
+        self.addTypingIndicatorMessage(false)
+
+        Task {
+            try? await Task.sleep(nanoseconds: UInt64(botDelayTime) * 1_000_000_000)
+            
+            if self.lastMessage?.contentType == Int16(ALMESSAGE_CONTENT_TYPING_INDICATOR) {
+                self.removeTypingIndicatorMessage()
+            }
+        }
+    }
 
     open func updateStatusReportForConversation(contactId: String, status: Int32) {
         guard let id = self.contactId, id == contactId else { return }
@@ -2136,6 +2160,7 @@ open class ALKConversationViewModel: NSObject, Localizable {
     }
 
     private func updateMessageStatus(filteredList: [ALMessage], status: Int32) {
+        self.showTypingIndicatorTillBotNewMessage()
         if !filteredList.isEmpty {
             let message = filteredList.first
             message?.status = status as NSNumber

--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -2160,7 +2160,9 @@ open class ALKConversationViewModel: NSObject, Localizable {
     }
 
     private func updateMessageStatus(filteredList: [ALMessage], status: Int32) {
-        self.showTypingIndicatorTillBotNewMessage()
+        if status == Int32(DELIVERED_AND_READ.rawValue) {
+            self.showTypingIndicatorTillBotNewMessage()
+        }
         if !filteredList.isEmpty {
             let message = filteredList.first
             message?.status = status as NSNumber


### PR DESCRIPTION
## Summary
- Added Typing Indicator botTypingIndicatorInterval Value check in App Settings api call.
- Added a function to show Typing Indicator till the bot message received. Typing Indicator will only be invoked for Bot only and when the message is sent.
- Fixed `ALKAppSettings` class for App Setting Api response decoding.
- Improved `newMessagesAdded` function to update newMessageInTable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced chat display to ensure new messages appear correctly with smoother scrolling.
  
- **New Features**
	- Introduced a more responsive typing indicator during bot interactions for an improved conversational experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->