### PR TITLE
[CM-2385] Disable Restart Conversation through Submit button | iOS SDK

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1220,6 +1220,14 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             alMqttConversationService.unSubscribe(toOpenChannel: viewModel.channelKey)
         }
     }
+    
+    // Disables replies if the conversation is resolved and restart button is hidden.
+    open func isConversationResolvedAndReplyEnabled() -> Bool {
+        guard let channel = ALChannelService().getChannelByKey(viewModel.channelKey) else {
+            return true
+        }
+        return !channel.isClosedConversation || !configuration.hideRestartConversationButton
+    }
 
     public func scrollViewWillBeginDecelerating(_: UIScrollView) {
         UIMenuController.shared.hideMenu()
@@ -1786,6 +1794,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     /// For templateId 3, formData is a string.
     /// But for templateId 11, formData is a dictionary.
     private func submitButtonSelected(metadata: [String: Any], text: String) {
+        guard isConversationResolvedAndReplyEnabled() else { return }
         guard
             let urlString = metadata["formAction"] as? String,
             let url = URL(string: urlString)
@@ -1822,6 +1831,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     func formSubmitButtonSelected(formSubmitData: FormDataSubmit?, messageModel: ALKMessageViewModel, isButtonClickDisabled: Bool) {
+        guard isConversationResolvedAndReplyEnabled() else { return }
         guard let formData = formSubmitData else {
             print("Invalid form data for submit")
             return


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Added the code to disable the Submit button when the Restart Conversation button is disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the chat interface to validate conversation status before allowing message or form submissions. Now, if a conversation is closed or inactive, submissions are prevented to ensure a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->