### PR TITLE
[CM-2395] Form Data Persist in Local Cache| iOS SDK

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -2018,10 +2018,10 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
             }
         }
         
-        for (position, (_, option)) in formData.dropDownFields {
+        for (position, option) in formData.dropDownFields {
             let element = viewModelItems[position]
             if let dropdownModel = element as? FormViewModelDropdownItem {
-                postFormData[dropdownModel.name] = option
+                postFormData[dropdownModel.name] = option.text // Access the `text` property
             }
         }
 

--- a/Sources/Utilities/ALKFormDataCache.swift
+++ b/Sources/Utilities/ALKFormDataCache.swift
@@ -7,29 +7,59 @@
 
 import Foundation
 /// `ALKFormDataCache`class will be used for form data cache
-class ALKFormDataCache {
-    static let shared = ALKFormDataCache()
+public class ALKFormDataCache {
+    public static let shared = ALKFormDataCache()
     private let cache = NSCache<NSString, FormDataSubmit>()
+    private let userDefaultsKeyPrefix = "KOMMUNICATE_FormDataCache_"
 
     private init() {
         cache.name = "FormDataCache"
     }
 
     func set(_ formDataSubmit: FormDataSubmit, for key: String) {
-        cache.setObject(formDataSubmit, forKey: key as NSString)
+        let cacheKey = key as NSString
+        cache.setObject(formDataSubmit, forKey: cacheKey)
+        
+        // Persist to UserDefaults
+        if let encodedData = try? JSONEncoder().encode(formDataSubmit) {
+            UserDefaults.standard.set(encodedData, forKey: userDefaultsKeyPrefix + key)
+        }
     }
 
     func getFormData(for key: String) -> FormDataSubmit? {
-        guard let formDataSubmit = cache.object(forKey: key as NSString) else {
-            return nil
+        let cacheKey = key as NSString
+        
+        // Check in-memory cache first
+        if let cachedData = cache.object(forKey: cacheKey) {
+            return cachedData
         }
-        return formDataSubmit
+        
+        // Fetch from UserDefaults
+        if let savedData = UserDefaults.standard.data(forKey: userDefaultsKeyPrefix + key),
+           let decodedData = try? JSONDecoder().decode(FormDataSubmit.self, from: savedData) {
+            cache.setObject(decodedData, forKey: cacheKey) // Store in cache for faster access next time
+            return decodedData
+        }
+        
+        return nil
     }
 
     func getFormDataWithDefaultObject(for key: String) -> FormDataSubmit {
-        guard let formDataSubmit = cache.object(forKey: key as NSString) else {
-            return FormDataSubmit()
+        return getFormData(for: key) ?? FormDataSubmit()
+    }
+    
+    /// Clears both in-memory and persistent cache
+    public func clearCache() {
+        cache.removeAllObjects() // Clear in-memory cache
+            
+        let userDefaults = UserDefaults.standard
+        let allKeys = userDefaults.dictionaryRepresentation().keys
+            
+        // Remove only keys related to FormDataCache
+        for key in allKeys where key.hasPrefix(userDefaultsKeyPrefix) {
+            userDefaults.removeObject(forKey: key)
         }
-        return formDataSubmit
+            
+        userDefaults.synchronize() // Ensure changes are applied
     }
 }

--- a/Sources/Utilities/ALKFormDataCache.swift
+++ b/Sources/Utilities/ALKFormDataCache.swift
@@ -10,7 +10,7 @@ import Foundation
 public class ALKFormDataCache {
     public static let shared = ALKFormDataCache()
     private let cache = NSCache<NSString, FormDataSubmit>()
-    private let userDefaultsKeyPrefix = "KOMMUNICATE_FormDataCache_"
+    private let userDefaultsKeyPrefix = "io.kommunicate.formDataCache."
 
     private init() {
         cache.name = "FormDataCache"

--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -426,8 +426,8 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             
             if let formDataSubmit = formData,
                let fields = formDataSubmit.dropDownFields[indexPath.section] {
-                cell.menu.selectedIndex = fields.0
-                cell.menu.text = cell.options?[fields.0].label
+                cell.menu.selectedIndex = fields.id
+                cell.menu.text = cell.options?[fields.id].label
             }
             
             if let validationField = formData?.validationFields[indexPath.section], validationField == FormData.inValid {
@@ -505,13 +505,13 @@ extension ALKFormCell: KMFormDropDownSelectionProtocol {
             print("Can't be updated due to incorrect index")
             return
         }
-        formSubmittedData.dropDownFields[position] = (index, selectedText)
+        formSubmittedData.dropDownFields[position] = DropDownField(id: index, text: selectedText)
         formData = formSubmittedData
     }
     
     func defaultOptionSelected(position: Int, selectedText: String?, index: Int) {
         guard let formSubmittedData = formData else { return }
-        formSubmittedData.dropDownFields[position] = (index, selectedText)
+        formSubmittedData.dropDownFields[position] = DropDownField(id: index, text: selectedText)
         formData = formSubmittedData
     }
 }
@@ -619,14 +619,21 @@ class NestedCellTableView: UITableView {
     }
 }
 
-class FormDataSubmit {
-    var textFields = [Int: String]()
-    var textViews = [Int: String]()
-    var singleSelectFields = [Int: Int]()
-    var multiSelectFields = [Int: [Int]]()
-    var dateFields = [Int: Int64]()
-    var dropDownFields = [Int: (Int, String?)]()
-    var validationFields = [Int: Int]()
+struct DropDownField: Codable {
+    var id: Int
+    var text: String?
+}
+
+class FormDataSubmit: Codable {
+    var textFields: [Int: String] = [:]
+    var textViews: [Int: String] = [:]
+    var singleSelectFields: [Int: Int] = [:]
+    var multiSelectFields: [Int: [Int]] = [:]
+    var dateFields: [Int: Int64] = [:]
+    var dropDownFields: [Int: DropDownField] = [:] // Replaced tuple with struct
+    var validationFields: [Int: Int] = [:]
+
+    init() {}
 }
 
 public struct KMHidePostCTAForm {


### PR DESCRIPTION
## Summary
- Added the code to update the form data in local storage in User Default Cache.
- Added the code to remove the data from cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced form data caching with persistent storage and a new cache clearing option, ensuring more consistent data retrieval.

- **Refactor**
  - Improved dropdown selection handling in forms for clearer, more reliable user input.
  - Updated data representation for dropdown fields to streamline form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->