### PR TITLE
[CM-2398] BUG: Form Text Area Placeholder not visible after clearing text | iOS SDK

### DIFF
--- a/Sources/Views/ALKFormCell.swift
+++ b/Sources/Views/ALKFormCell.swift
@@ -130,7 +130,6 @@ class ALKFormCell: ALKChatBaseCell<ALKMessageViewModel>, UITextFieldDelegate, UI
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         activeTextView = textView
-        textView.text = nil
         textView.textColor = .kmDynamicColor(light: .black, dark: .white)
     }
 
@@ -233,6 +232,12 @@ extension ALKFormCell: UITableViewDataSource, UITableViewDelegate {
             cell.item = item
             cell.valueTextField.delegate = self
             cell.valueTextField.tag = indexPath.section
+            if let formDataSubmit = formData,
+               let text = formDataSubmit.textViews[indexPath.section] {
+                cell.valueTextField.text = text
+            } else {
+                cell.valueTextField.text = ""
+            }
             if let validationField = formData?.validationFields[indexPath.section], validationField == FormData.inValid {
                 let formViewModelTextAreaItem = item as? FormViewModelTextAreaItem
                 cell.errorLabel.text = formViewModelTextAreaItem?.validation?.errorText ?? localizedString(forKey: "InvalidDatErrorInForm", withDefaultValue: SystemMessage.UIError.InvalidDatErrorInForm, fileName: localizedStringFileName)

--- a/Sources/Views/ALKFormTextItemCell.swift
+++ b/Sources/Views/ALKFormTextItemCell.swift
@@ -98,8 +98,7 @@ class ALKFormTextAreaItemCell: UITableViewCell {
                 return
             }
             nameLabel.text = item.title
-            valueTextField.text = item.placeholder
-            valueTextField.textColor = .lightGray
+            valueTextField.placeholder = item.placeholder
         }
     }
 
@@ -240,6 +239,28 @@ class KMPaddedTextView: UITextView {
         }
     }
 
+    var placeholder: String? {
+        didSet {
+            placeholderLabel.text = placeholder
+            updatePlaceholderVisibility()
+        }
+    }
+
+    private lazy var placeholderLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .lightGray  // Placeholder color
+        label.font = self.font
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    override var text: String! {
+        didSet {
+            updatePlaceholderVisibility()
+        }
+    }
+
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         commonInit()
@@ -252,5 +273,39 @@ class KMPaddedTextView: UITextView {
 
     private func commonInit() {
         textContainerInset = textPadding
+        textColor = .black  // Ensure default text color is black
+        addSubview(placeholderLabel)
+
+        NSLayoutConstraint.activate([
+            placeholderLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: textPadding.left + 5),
+            placeholderLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -textPadding.right - 5),
+            placeholderLabel.topAnchor.constraint(equalTo: topAnchor, constant: textPadding.top)
+        ])
+
+        NotificationCenter.default.addObserver(self, selector: #selector(textDidChange), name: UITextView.textDidChangeNotification, object: self)
+        delegate = self
+    }
+
+    @objc private func textDidChange() {
+        updatePlaceholderVisibility()
+    }
+
+    private func updatePlaceholderVisibility() {
+        placeholderLabel.isHidden = !(text?.isEmpty ?? true)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}
+
+// MARK: - UITextViewDelegate
+extension KMPaddedTextView: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        textView.textColor = .black // Ensure text color is black when typing
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        textView.textColor = textView.text.isEmpty ? .lightGray : .black
     }
 }

--- a/Sources/Views/ALKFormTextItemCell.swift
+++ b/Sources/Views/ALKFormTextItemCell.swift
@@ -273,7 +273,7 @@ class KMPaddedTextView: UITextView {
 
     private func commonInit() {
         textContainerInset = textPadding
-        textColor = .black  // Ensure default text color is black
+        textColor = .kmDynamicColor(light: .black, dark: .white)
         addSubview(placeholderLabel)
 
         NSLayoutConstraint.activate([
@@ -302,10 +302,10 @@ class KMPaddedTextView: UITextView {
 // MARK: - UITextViewDelegate
 extension KMPaddedTextView: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
-        textView.textColor = .black // Ensure text color is black when typing
+        textView.textColor = .kmDynamicColor(light: .black, dark: .white)
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        textView.textColor = textView.text.isEmpty ? .lightGray : .black
+        textView.textColor = textView.text.isEmpty ? .lightGray : .kmDynamicColor(light: .black, dark: .white)
     }
 }


### PR DESCRIPTION
## Summary
- Updated the flow of placeholder updation in text area.
- Added the code to show saved data in text area.

## Video 
- Before :  

https://github.com/user-attachments/assets/2b673578-463c-40b9-8b8d-203839500b53

- After : 
 
https://github.com/user-attachments/assets/3d08cdee-22c8-4240-b7a3-29dab87fc362



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text input fields to retain user-entered content during editing sessions, preventing unexpected clearing.
  
- **New Features**
  - Introduced a dedicated placeholder for text areas, offering clearer guidance and a more standard visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->