### PR TITLE
[CM-1289] Expose Events with correct data to endusers | iOS SDK

### DIFF
--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -1051,6 +1051,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 weakSelf.viewModel.send(voiceMessage: voice as Data, metadata: self?.configuration.messageMetadata)
 
             case .startVideoRecord:
+                ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.videoButtonClicked, data: nil)
                 if UIImagePickerController.isSourceTypeAvailable(.camera) {
                     AVCaptureDevice.requestAccess(for: AVMediaType.video, completionHandler: {
                         granted in
@@ -1079,6 +1080,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                     weakSelf.showAlertForApplicationSettings(title: title, message: msg)
                 }
             case .showImagePicker:
+                ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.attachmentOptionClicked, data: ["attachmentType": "Image/Video"])
                 if #available(iOS 14, *), weakSelf.configuration.isNewSystemPhotosUIEnabled {
                     weakSelf.photoPicker.openGallery(from: weakSelf)
                 } else {
@@ -1089,6 +1091,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                     weakSelf.present(vc, animated: true, completion: nil)
                 }
             case .showLocation:
+                ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.locationButtonClicked, data: nil)
                 let storyboard = UIStoryboard.name(storyboard: UIStoryboard.Storyboard.mapView, bundle: Bundle.km)
 
                 guard let nav = storyboard.instantiateInitialViewController() as? ALKBaseNavigationViewController else { return }
@@ -1097,6 +1100,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 mapViewVC.setConfiguration(weakSelf.configuration)
                 self?.present(nav, animated: true, completion: {})
             case let .cameraButtonClicked(button):
+                ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.cameraButtonClicked, data: nil)
                 guard let vc = ALKCustomCameraViewController.makeInstanceWith(delegate: weakSelf, and: weakSelf.configuration)
                 else {
                     button.isUserInteractionEnabled = true
@@ -1105,6 +1109,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
                 weakSelf.present(vc, animated: true, completion: nil)
                 button.isUserInteractionEnabled = true
             case .showDocumentPicker:
+                ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.attachmentOptionClicked, data: ["attachmentType": "Document"])
                 weakSelf.documentManager.showPicker(from: weakSelf)
             case .languageSelection:
                 weakSelf.showLanguageSelection()
@@ -2387,6 +2392,9 @@ extension ALKConversationViewController: ALKConversationViewModelDelegate {
         }
         guard !viewModel.isOpenGroup else { return }
         viewModel.markConversationRead()
+        if let channelKey = viewModel.channelKey {
+            ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.currentOpenedConversation, data: ["conversationId": Int(truncating: channelKey)])
+        }
     }
 
     public func messageUpdated() {

--- a/Sources/CustomEvent/ALKCustomEventCallback.swift
+++ b/Sources/CustomEvent/ALKCustomEventCallback.swift
@@ -19,4 +19,18 @@ public protocol ALKCustomEventCallback: AnyObject {
     func ratingSubmitted(conversationId: String, rating: Int, comment: String)
     func richMessageClicked(conversationId: String, action: Any, type: String)
     func conversationInfoClicked()
+    func currentOpenedConversation(conversationId: String)
+    func attachmentOptionClicked(attachemntType: String)
+    func voiceButtonClicked(currentState: KMVoiceRecordingState)
+    func locationButtonClicked()
+    func rateConversationEmotionsClicked(rating: Int)
+    func cameraButtonClicked()
+    func videoButtonClicked()
+}
+
+// Voice Recording Sate
+public enum KMVoiceRecordingState: String {
+    case started = "Voice Recording Started"
+    case stopped = "Voice Recording Stopped"
+    case cancelled = "Voice Recording Cancelled"
 }

--- a/Sources/CustomEvent/ALKCustomEventHandler.swift
+++ b/Sources/CustomEvent/ALKCustomEventHandler.swift
@@ -23,60 +23,89 @@ public class ALKCustomEventHandler {
               subscribedEvents.contains(triggeredEvent) else { return }
 
         switch triggeredEvent {
-            case .faqClick:
-                if let url = data?["faqUrl"] as? URL {
-                    delegate.faqClicked(url: url.absoluteString)
-                } else if let urlString = data?["faqUrl"] as? String,
-                          let url = URL(string: urlString) {
-                    delegate.faqClicked(url: url.absoluteString)
-                }
+        case .faqClick:
+            if let url = data?["faqUrl"] as? URL {
+                delegate.faqClicked(url: url.absoluteString)
+            } else if let urlString = data?["faqUrl"] as? String,
+                      let url = URL(string: urlString) {
+                delegate.faqClicked(url: url.absoluteString)
+            }
 
-            case .messageSend:
-                if let message = data?["message"] as? ALMessage {
-                    delegate.messageSent(message: message)
-                }
+        case .messageSend:
+            if let message = data?["message"] as? ALMessage {
+                delegate.messageSent(message: message)
+            }
 
-            case .newConversation:
-                if let conversationId = data?["conversationId"] as? String {
-                    delegate.conversationCreated(conversationId: conversationId)
-                }
+        case .newConversation:
+            if let conversationId = data?["conversationId"] as? String {
+                delegate.conversationCreated(conversationId: conversationId)
+            }
 
-            case .submitRatingClick:
-                if let conversationId = data?["conversationId"] as? Int,
-                   let rating = data?["rating"] as? Int,
-                   let comment = data?["comment"] as? String {
-                    delegate.ratingSubmitted(conversationId: String(conversationId), rating: rating, comment: comment)
-                }
+        case .submitRatingClick:
+            if let conversationId = data?["conversationId"] as? Int,
+                let rating = data?["rating"] as? Int,
+                let comment = data?["comment"] as? String {
+                delegate.ratingSubmitted(conversationId: String(conversationId), rating: rating, comment: comment)
+            }
 
-            case .resolveConversation:
-                if let conversationId = data?["conversationId"] as? String {
-                    delegate.conversationResolved(conversationId: conversationId)
-                }
+        case .resolveConversation:
+            if let conversationId = data?["conversationId"] as? String {
+                delegate.conversationResolved(conversationId: conversationId)
+            }
 
-            case .restartConversationClick:
-                if let conversationId = data?["conversationId"] as? Int {
-                    delegate.conversationRestarted(conversationId: String(conversationId))
-                }
+        case .restartConversationClick:
+            if let conversationId = data?["conversationId"] as? Int {
+                delegate.conversationRestarted(conversationId: String(conversationId))
+            }
 
-            case .richMessageClick:
-                let conversationId = data?["conversationId"] as? String ?? ""
-                let action = data?["action"] ?? "Action Not Present"
-                let type = data?["type"] as? String ?? ""
-                delegate.richMessageClicked(conversationId: conversationId, action: action, type: type)
+        case .richMessageClick:
+            let conversationId = data?["conversationId"] as? String ?? ""
+            let action = data?["action"] ?? "Action Not Present"
+            let type = data?["type"] as? String ?? ""
+            delegate.richMessageClicked(conversationId: conversationId, action: action, type: type)
 
-            case .conversationBackPress:
-                delegate.onBackButtonClick(isConversationOpened: true)
+        case .conversationBackPress:
+            delegate.onBackButtonClick(isConversationOpened: true)
 
-            case .conversationListBackPress:
-                delegate.onBackButtonClick(isConversationOpened: false)
+        case .conversationListBackPress:
+            delegate.onBackButtonClick(isConversationOpened: false)
 
-            case .messageReceive:
-                if let messages = data?["messageList"] as? [ALMessage] {
-                    messages.forEach { delegate.messageReceived(message: $0) }
-                }
+        case .messageReceive:
+            if let messages = data?["messageList"] as? [ALMessage] {
+                messages.forEach { delegate.messageReceived(message: $0) }
+            }
 
-            case .conversationInfoClick:
-                delegate.conversationInfoClicked()
+        case .conversationInfoClick:
+            delegate.conversationInfoClicked()
+        
+        case .attachmentOptionClicked:
+            if let attachmentType = data?["attachmentType"] as? String {
+                delegate.attachmentOptionClicked(attachemntType: attachmentType)
+            }
+            
+        case .voiceButtonClicked:
+            if let currentState = data?["currentState"] as? KMVoiceRecordingState {
+                delegate.voiceButtonClicked(currentState: currentState)
+            }
+            
+        case .locationButtonClicked:
+            delegate.locationButtonClicked()
+            
+        case .rateConversationEmotionsClicked:
+            if let rating = data?["rating"] as? Int {
+                delegate.rateConversationEmotionsClicked(rating: rating)
+            }
+            
+        case .cameraButtonClicked:
+            delegate.cameraButtonClicked()
+            
+        case .videoButtonClicked:
+            delegate.videoButtonClicked()
+            
+        case .currentOpenedConversation:
+            if let conversationId = data?["conversationId"] as? Int {
+                delegate.currentOpenedConversation(conversationId: String(conversationId))
+            }
         }
     }
 

--- a/Sources/CustomEvent/KMCustomEvent.swift
+++ b/Sources/CustomEvent/KMCustomEvent.swift
@@ -17,6 +17,13 @@ public enum KMCustomEvent: String, CaseIterable {
     case conversationListBackPress = "ON_CONVERSATION_LIST_BACK_CLICK"
     case messageReceive = "ON_MESSAGE_RECEIVE"
     case conversationInfoClick = "ON_CONVERSATION_INFO_CLICK"
+    case attachmentOptionClicked = "ON_ATTACHEMENT_OPTION_CLICK"
+    case voiceButtonClicked = "ON_VOICE_BUTTON_CLICK"
+    case locationButtonClicked = "ON_LOCATION_BUTTON_CLICK"
+    case rateConversationEmotionsClicked = "ON_RATE_CONVERSATION_EMOTIONS_CLICK"
+    case cameraButtonClicked = "ON_CAMERA_BUTTON_CLICK"
+    case videoButtonClicked = "ON_VIDEO_BUTTON_CLICK"
+    case currentOpenedConversation = "ON_CURRENT_OPENED_CONVERSATION"
     
     public static var allEvents: [KMCustomEvent] {
         return Array(self.allCases)

--- a/Sources/Views/ALKChatBar.swift
+++ b/Sources/Views/ALKChatBar.swift
@@ -854,12 +854,14 @@ extension ALKChatBar: UITextViewDelegate {
 
 extension ALKChatBar: ALKAudioRecorderProtocol {
     public func startRecordingAudio() {
+        ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.voiceButtonClicked, data: ["currentState": KMVoiceRecordingState.started])
         changeButton()
         action?(.startVoiceRecord)
         soundRec.userDidStartRecording()
     }
 
     public func finishRecordingAudio(soundData: NSData) {
+        ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.voiceButtonClicked, data: ["currentState": KMVoiceRecordingState.stopped])
         textView.resignFirstResponder()
         if soundRec.isRecordingTimeSufficient() {
             action?(.sendVoice(soundData))
@@ -868,6 +870,7 @@ extension ALKChatBar: ALKAudioRecorderProtocol {
     }
 
     public func cancelRecordingAudio() {
+        ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.voiceButtonClicked, data: ["currentState": KMVoiceRecordingState.cancelled])
         stopRecording()
     }
 
@@ -882,6 +885,7 @@ extension ALKChatBar: ALKAudioRecorderProtocol {
 
 extension ALKChatBar: ALKAudioRecorderViewProtocol {
     public func cancelAudioRecording() {
+        ALKCustomEventHandler.shared.publish(triggeredEvent: KMCustomEvent.voiceButtonClicked, data: ["currentState": KMVoiceRecordingState.cancelled])
         #if !SPEECH_REC
             micButton.cancelAudioRecord()
         #endif


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Exposed `currentOpenedConversation` , `videoButtonClicked`, `cameraButtonClicked`, `rateConversationEmotionsClicked`, `locationButtonClicked`, `voiceButtonClicked` and `attachmentOptionClicked`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tracking of user interactions within the conversation interface. Now, actions such as video recording, image and document attachment selections, camera usage, location sharing, and audio recording (with distinct start, stop, and cancel states) are captured.
  - Improved monitoring of conversation engagement to support a more responsive messaging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->