### PR TITLE
[CM-2330] Pass language code from IOS in both format "en" and "en_US" - lex bot requirement

### DIFF
--- a/Sources/ViewModels/ALKConversationViewModel.swift
+++ b/Sources/ViewModels/ALKConversationViewModel.swift
@@ -1019,6 +1019,13 @@ open class ALKConversationViewModel: NSObject, Localizable {
         
         updateMessageMetadataChatContext(info: ["kmUserLocale": languageCode as Any], metadata: metaData)
         
+        /// For Dialogflow bot, pass language code with region using key `kmUserLanguageCode`
+        if let languageCodeWithRegion = [Locale.current.languageCode, Locale.current.regionCode]
+            .compactMap({ $0 })
+            .joined(separator: "_") as String?, !languageCodeWithRegion.isEmpty {
+            updateMessageMetadataChatContext( info: ["kmUserLanguageCode": languageCodeWithRegion], metadata: metaData)
+        }
+        
         return metaData
     }
     


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Added the Code for Dialogflow bot, pass language code with region using key `kmUserLanguageCode`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced message metadata for Dialogflow bots to include both the user's language code and a combined language-region code, improving language context handling in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->