### PR TITLE
[CM-2410] Video Attachment Preview Flow Improvement | iOS SDK

### DIFF
--- a/Sources/Controllers/KMMediaViewerViewController.swift
+++ b/Sources/Controllers/KMMediaViewerViewController.swift
@@ -1,0 +1,135 @@
+//
+//  KMMediaViewerViewController.swift
+//  KommunicateChatUI-iOS-SDK
+//
+//  Created by Abhijeet Ranjan on 24/04/25.
+//
+
+import UIKit
+import AVKit
+
+final class KMMediaViewerViewController: UIViewController {
+
+    // MARK: - Properties
+
+    private let viewModel: ALKMediaViewerViewModel
+    private var playerViewController: AVPlayerViewController?
+
+    // MARK: - Initialization
+
+    init(viewModel: ALKMediaViewerViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        self.viewModel.delegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        setupNavigationBar()
+        setupCloseButtonIfNeeded()
+        playCurrentVideo()
+    }
+
+    // MARK: - Setup Methods
+
+    private func setupView() {
+        view.backgroundColor = .black
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.title = viewModel.getTitle()
+    }
+
+    private func setupCloseButtonIfNeeded() {
+        guard isPresentedModally(),
+              let closeImage = UIImage(named: "close", in: Bundle.km, compatibleWith: nil)?
+                .withRenderingMode(.alwaysTemplate) else { return }
+
+        let closeButton = KMExtendedTouchAreaButton(type: .custom)
+        closeButton.setImage(closeImage, for: .normal)
+        closeButton.tintColor = .white
+        closeButton.backgroundColor = .clear
+        closeButton.imageView?.contentMode = .scaleAspectFit
+        closeButton.addTarget(self, action: #selector(dismissViewController), for: .touchUpInside)
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+    }
+
+    // MARK: - Video Playback
+
+    private func playCurrentVideo() {
+        guard
+            let message = viewModel.getMessageForCurrentIndex(),
+            let filePath = message.filePath,
+            !filePath.isEmpty
+        else {
+            print("Local video file path is missing")
+            return
+        }
+
+        let videoURL = viewModel.getURLFor(name: filePath)
+
+        guard FileManager.default.fileExists(atPath: videoURL.path) else {
+            print("⚠️ Video file does not exist at path: \(videoURL.path)")
+            return
+        }
+
+        print("🎥 Playing video from: \(videoURL.path)")
+        setupPlayer(with: videoURL)
+    }
+
+    private func setupPlayer(with url: URL) {
+        let player = AVPlayer(url: url)
+        let playerVC = AVPlayerViewController()
+        playerVC.player = player
+        playerVC.showsPlaybackControls = true
+        playerVC.view.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(playerVC)
+        view.addSubview(playerVC.view)
+        playerVC.didMove(toParent: self)
+
+        NSLayoutConstraint.activate([
+            playerVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            playerVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            playerVC.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            playerVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        player.play()
+        self.playerViewController = playerVC
+    }
+
+    // MARK: - Actions
+
+    @objc private func dismissViewController() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    // MARK: - Utility
+
+    private func isPresentedModally() -> Bool {
+        presentingViewController != nil ||
+        navigationController?.presentingViewController?.presentedViewController == navigationController
+    }
+}
+
+// MARK: - ALKMediaViewerViewModelDelegate
+
+extension KMMediaViewerViewController: ALKMediaViewerViewModelDelegate {
+    func reloadView() {
+        navigationItem.title = viewModel.getTitle()
+        playerViewController?.player?.pause()
+        playerViewController?.view.removeFromSuperview()
+        playerViewController?.removeFromParent()
+        playerViewController = nil
+        playCurrentVideo()
+    }
+}

--- a/Sources/Controllers/KMMediaViewerViewController.swift
+++ b/Sources/Controllers/KMMediaViewerViewController.swift
@@ -36,6 +36,11 @@ final class KMMediaViewerViewController: UIViewController {
         setupCloseButtonIfNeeded()
         playCurrentVideo()
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        playerViewController?.player?.pause()
+    }
 
     // MARK: - Setup Methods
 

--- a/Sources/Views/ALKVideoCell.swift
+++ b/Sources/Views/ALKVideoCell.swift
@@ -224,16 +224,6 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
     }
 
     @objc private func playButtonAction(_: UIButton) {
-        let initialVC = UIStoryboard.name(
-            storyboard: UIStoryboard.Storyboard.mediaViewer,
-            bundle: Bundle.km
-        )
-        .instantiateInitialViewController()
-        guard let nav = initialVC as? ALKBaseNavigationViewController,
-              let vc = nav.viewControllers.first as? ALKMediaViewerViewController
-        else {
-            return
-        }
         let dbService = ALMessageDBService()
         guard let messages = dbService.getAllMessagesWithAttachment(
             forContact: viewModel?.contactId,
@@ -246,7 +236,16 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
 
         guard let viewModel = viewModel as? ALKMessageModel,
               let currentIndex = messageModels.firstIndex(of: viewModel) else { return }
-        vc.viewModel = ALKMediaViewerViewModel(messages: messageModels, currentIndex: currentIndex, localizedStringFileName: localizedStringFileName)
+
+        let mediaViewerViewModel = ALKMediaViewerViewModel(
+            messages: messageModels,
+            currentIndex: currentIndex,
+            localizedStringFileName: localizedStringFileName
+        )
+        
+        let mediaVC = KMMediaViewerViewController(viewModel: mediaViewerViewModel)
+        let nav = ALKBaseNavigationViewController(rootViewController: mediaVC)
+        nav.modalPresentationStyle = .formSheet
         UIViewController.topViewController()?.present(nav, animated: true, completion: {
             self.playButton.isEnabled = true
         })


### PR DESCRIPTION
## Summary

- Introduced `KMMediaViewerViewController` for handling media playback.
- Enables users to play videos directly within the preview screen.
- Adds support for full-screen video viewing.

## Videos (Before - After)

### Before: 

https://github.com/user-attachments/assets/1b4f44a1-ad11-4e41-a01f-eafbefd2787f

### After: 

https://github.com/user-attachments/assets/c07c3f99-93bb-47e3-a446-538291195393



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dedicated media viewer for video playback within chat, offering an improved viewing experience with automatic playback and easy dismissal.
- **Refactor**
	- Streamlined how videos are opened from chat, enabling direct presentation of the new media viewer for smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->