### PR TITLE
[CM-2428] Add support for caption in video | iOS SDK 

### DIFF
--- a/Sources/Views/ALKFriendVideoCell.swift
+++ b/Sources/Views/ALKFriendVideoCell.swift
@@ -82,13 +82,11 @@ class ALKFriendVideoCell: ALKVideoCell {
         photoView.trailingAnchor
             .constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -Padding.PhotoView.right)
             .isActive = true
-
-        photoView.heightAnchor
-            .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.heightPercentage)
-            .isActive = true
-        
         photoView.widthAnchor
             .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.widthPercentage)
+            .isActive = true
+        photoView.heightAnchor
+            .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.heightPercentage)
             .isActive = true
 
         timeLabel.leadingAnchor.constraint(equalTo: bubbleView.trailingAnchor, constant: 2).isActive = true

--- a/Sources/Views/ALKFriendVideoCell.swift
+++ b/Sources/Views/ALKFriendVideoCell.swift
@@ -35,9 +35,17 @@ class ALKFriendVideoCell: ALKVideoCell {
         return 28
     }
 
+    enum Padding {
+        enum PhotoView {
+            static let right: CGFloat = 56
+        }
+    }
+
     override func setupStyle() {
         super.setupStyle()
         nameLabel.setStyle(ALKMessageStyle.displayName)
+        captionLabel.font = ALKMessageStyle.receivedMessage.font
+        captionLabel.textColor = ALKMessageStyle.receivedMessage.text
         if ALKMessageStyle.receivedBubble.style == .edge {
             bubbleView.layer.cornerRadius = ALKMessageStyle.receivedBubble.cornerRadius
             bubbleView.backgroundColor = appSettingsUserDefaults.getReceivedMessageBackgroundColor()
@@ -49,7 +57,6 @@ class ALKFriendVideoCell: ALKVideoCell {
 
     override func setupViews() {
         super.setupViews()
-        let width = UIScreen.main.bounds.width
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(avatarTappedAction))
         avatarImageView.addGestureRecognizer(tapGesture)
@@ -72,11 +79,17 @@ class ALKFriendVideoCell: ALKVideoCell {
         avatarImageView.heightAnchor.constraint(equalToConstant: 37).isActive = true
         avatarImageView.widthAnchor.constraint(equalTo: avatarImageView.heightAnchor).isActive = true
 
-        photoView.trailingAnchor.constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -56).isActive = true
-        photoView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16).isActive = true
+        photoView.trailingAnchor
+            .constraint(lessThanOrEqualTo: contentView.trailingAnchor, constant: -Padding.PhotoView.right)
+            .isActive = true
 
-        photoView.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 6).isActive = true
-        photoView.widthAnchor.constraint(equalToConstant: width * 0.60).isActive = true
+        photoView.heightAnchor
+            .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.heightPercentage)
+            .isActive = true
+        
+        photoView.widthAnchor
+            .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.widthPercentage)
+            .isActive = true
 
         timeLabel.leadingAnchor.constraint(equalTo: bubbleView.trailingAnchor, constant: 2).isActive = true
         timeLabel.bottomAnchor.constraint(equalTo: bubbleView.bottomAnchor, constant: 2).isActive = true

--- a/Sources/Views/ALKMyVideoCell.swift
+++ b/Sources/Views/ALKMyVideoCell.swift
@@ -32,9 +32,6 @@ class ALKMyVideoCell: ALKVideoCell {
             .constraint(equalTo: contentView.topAnchor, constant: Padding.PhotoView.top)
             .isActive = true
 
-        photoView.leadingAnchor
-            .constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 48)
-            .isActive = true
         photoView.trailingAnchor
             .constraint(equalTo: contentView.trailingAnchor, constant: -Padding.PhotoView.right)
             .isActive = true

--- a/Sources/Views/ALKMyVideoCell.swift
+++ b/Sources/Views/ALKMyVideoCell.swift
@@ -14,22 +14,39 @@ class ALKMyVideoCell: ALKVideoCell {
         sv.contentMode = .center
         return sv
     }()
+    
+    enum Padding {
+        enum PhotoView {
+            static let right: CGFloat = 14
+            static let top: CGFloat = 6
+        }
+    }
 
     let appSettingsUserDefaults = ALKAppSettingsUserDefaults()
     override func setupViews() {
         super.setupViews()
 
-        let width = UIScreen.main.bounds.width
-
         contentView.addViewsForAutolayout(views: [stateView])
 
-        photoView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6).isActive = true
+        photoView.topAnchor
+            .constraint(equalTo: contentView.topAnchor, constant: Padding.PhotoView.top)
+            .isActive = true
 
-        photoView.leadingAnchor.constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 48).isActive = true
-        photoView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -14).isActive = true
+        photoView.leadingAnchor
+            .constraint(greaterThanOrEqualTo: contentView.leadingAnchor, constant: 48)
+            .isActive = true
+        photoView.trailingAnchor
+            .constraint(equalTo: contentView.trailingAnchor, constant: -Padding.PhotoView.right)
+            .isActive = true
 
-        photoView.widthAnchor.constraint(equalToConstant: width * 0.60).isActive = true
-        photoView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -6).isActive = true
+        photoView.widthAnchor
+            .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.widthPercentage)
+            .isActive = true
+        photoView.heightAnchor
+            .constraint(equalToConstant: ALKVideoCell.maxWidth * ALKVideoCell.heightPercentage)
+            .isActive = true
+
+        bubbleView.backgroundColor = UIColor.hex8(Color.Background.grayF2.rawValue).withAlphaComponent(0.26)
 
         fileSizeLabel.rightAnchor.constraint(equalTo: bubbleView.rightAnchor, constant: 0).isActive = true
         stateView.bottomAnchor.constraint(equalTo: bubbleView.bottomAnchor, constant: -1.0).isActive = true
@@ -57,6 +74,8 @@ class ALKMyVideoCell: ALKVideoCell {
             photoView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
             bubbleView.layer.cornerRadius = ALKMessageStyle.sentBubble.cornerRadius
         }
+        captionLabel.font = ALKMessageStyle.sentMessage.font
+        captionLabel.textColor = ALKMessageStyle.sentMessage.text
         setStatusStyle(statusView: stateView, ALKMessageStyle.messageStatus)
     }
 }

--- a/Sources/Views/ALKVideoCell.swift
+++ b/Sources/Views/ALKVideoCell.swift
@@ -36,7 +36,7 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
         }
     }
     
-    // To be changed from the class that is subclassing `ALKPhotoCell`
+    // To be changed from the class that is subclassing `ALVideoCell`
     class var messageTextFont: UIFont {
         return Font.normal(size: 12).font()
     }
@@ -132,23 +132,31 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
         return 16
     }
 
-    override class func rowHeigh(viewModel: ALKMessageViewModel, width: CGFloat) -> CGFloat {
-        var height: CGFloat
+    override class func rowHeigh(
+        viewModel: ALKMessageViewModel,
+        width: CGFloat
+    ) -> CGFloat {
+        var mediaHeight = ceil(width * heightPercentage)
 
-        if viewModel.ratio < 1 {
-            height = viewModel.ratio == 0 ? (width * heightPercentage) : ceil((width * heightPercentage) / viewModel.ratio)
-        } else {
-            height = ceil((width * 0.64) / viewModel.ratio)
-        }
-        
         if let message = viewModel.message, !message.isEmpty {
-            height += message.rectWithConstrainedWidth(
-                width * widthPercentage,
+            if viewModel.ratio < 1 {
+                mediaHeight = viewModel.ratio == 0
+                    ? ceil(width * heightPercentage)
+                    : ceil((width * heightPercentage) / viewModel.ratio)
+            } else {
+                mediaHeight = ceil((width * 0.64) / viewModel.ratio)
+            }
+
+            let messageWidth = width * widthPercentage
+            let messageHeight = message.rectWithConstrainedWidth(
+                messageWidth,
                 font: messageTextFont
-            ).height.rounded(.up) + Padding.CaptionLabel.bottom
+            ).height.rounded(.up)
+
+            mediaHeight += messageHeight + Padding.CaptionLabel.bottom
         }
 
-        return topPadding() + height + bottomPadding()
+        return topPadding() + mediaHeight + bottomPadding()
     }
 
     override func update(viewModel: ALKMessageViewModel) {
@@ -227,6 +235,8 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
         bubbleView.bottomAnchor.constraint(equalTo: captionLabel.bottomAnchor).isActive = true
         bubbleView.leftAnchor.constraint(equalTo: photoView.leftAnchor).isActive = true
         bubbleView.rightAnchor.constraint(equalTo: photoView.rightAnchor).isActive = true
+        
+        fileSizeLabel.topAnchor.constraint(equalTo: bubbleView.bottomAnchor, constant: 2).isActive = true
 
         downloadButton.centerXAnchor.constraint(equalTo: photoView.centerXAnchor).isActive = true
         downloadButton.centerYAnchor.constraint(equalTo: photoView.centerYAnchor).isActive = true
@@ -247,8 +257,6 @@ class ALKVideoCell: ALKChatBaseCell<ALKMessageViewModel>,
         progressView.centerYAnchor.constraint(equalTo: photoView.centerYAnchor).isActive = true
         progressView.heightAnchor.constraint(equalToConstant: 60).isActive = true
         progressView.widthAnchor.constraint(equalToConstant: 60).isActive = true
-
-        fileSizeLabel.topAnchor.constraint(equalTo: bubbleView.bottomAnchor, constant: 2).isActive = true
         
         captionLabel.layout {
             $0.leading == photoView.leadingAnchor + Padding.CaptionLabel.left


### PR DESCRIPTION
## Summary
- Added a Caption Section in Video Cells.
- Added Support for Sent and Received Video Cells.
- Updated the code of row height for video Cell.
- Refactored the code of `setupViews()`

## Image

<img src ='https://github.com/user-attachments/assets/7b472114-c559-4008-830f-ef08e9d187db' height = 450>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying a caption below video thumbnails in video message cells.
- **Style**
  - Improved layout and sizing of video message cells for better alignment and consistent padding.
  - Updated caption label styling to match message styles.
- **Refactor**
  - Centralized layout constants for easier maintenance and consistency across video message cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->