### PR TITLE
[CM-2439] Update UI Message to Indicate Subscription Requirement in Release Mode | iOS SDK

### DIFF
--- a/Sources/Controllers/ALKAccountSuspensionController.swift
+++ b/Sources/Controllers/ALKAccountSuspensionController.swift
@@ -7,17 +7,73 @@
 
 import UIKit
 
-public class ALKAccountSuspensionController: UIViewController {
+public class ALKAccountSuspensionController: UIViewController, Localizable {
+    public var configuration: ALKConfiguration!
+    static let CurrentActivatedPlan = "KM_CURRENT_ACTIVATED_PLAN"
+
+    public required init(configuration: ALKConfiguration) {
+        self.configuration = configuration
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     /// When the close button is tapped this will be called.
     public var closePressed: (() -> Void)?
 
     override public func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
+        setupMessageLabel()
     }
 
     @objc func closeButtonAction(_: UIButton) {
         closePressed?()
+    }
+    
+    @IBOutlet weak var messageLabel: UILabel!
+    
+    private enum UserPlanType: String {
+        case trial, churn, other
+
+        static func from(_ plan: String) -> UserPlanType {
+            let lowercasedPlan = plan.lowercased()
+            if lowercasedPlan.contains("trial") {
+                return .trial
+            } else if lowercasedPlan.contains("churn") {
+                return .churn
+            } else {
+                return .other
+            }
+        }
+    }
+
+    func setupMessageLabel() {
+        let userDefaults = UserDefaults(suiteName: "group.kommunicate.sdk") ?? .standard
+        let currentPlan = userDefaults.string(forKey: ALKAccountSuspensionController.CurrentActivatedPlan) ?? ""
+        let planType = UserPlanType.from(currentPlan)
+
+        let (key, defaultValue): (String, String)
+
+        switch planType {
+        case .trial:
+            key = "TrialUserDisconnectionMessage"
+            defaultValue = SystemMessage.SuspendedScreen.TrialUserDisconnectionMessage
+        case .churn:
+            key = "ChurnedUserDisconnectionMessage"
+            defaultValue = SystemMessage.SuspendedScreen.ChurnedUserDisconnectionMessage
+        case .other:
+            key = "MobileNotSupportedMessage"
+            defaultValue = SystemMessage.SuspendedScreen.MobileNotSupportedMessage
+        }
+
+        messageLabel.text = localizedString(
+            forKey: key,
+            withDefaultValue: defaultValue,
+            fileName: configuration.localizedStringFileName
+        )
     }
 
     private func setupViews() {

--- a/Sources/Controllers/ALKConversationListViewController.swift
+++ b/Sources/Controllers/ALKConversationListViewController.swift
@@ -341,7 +341,7 @@ open class ALKConversationListViewController: ALKBaseViewController, Localizable
     }
 
     override open func showAccountSuspensionView() {
-        let accountVC = ALKAccountSuspensionController()
+        let accountVC = ALKAccountSuspensionController(configuration: configuration)
         accountVC.isModalInPresentation = true
         accountVC.closePressed = { [weak self] in
             self?.dismiss(animated: true, completion: nil)

--- a/Sources/Controllers/ALKConversationViewController.swift
+++ b/Sources/Controllers/ALKConversationViewController.swift
@@ -609,7 +609,7 @@ open class ALKConversationViewController: ALKBaseViewController, Localizable {
     }
 
     override open func showAccountSuspensionView() {
-        let accountVC = ALKAccountSuspensionController()
+        let accountVC = ALKAccountSuspensionController(configuration: configuration)
         accountVC.isModalInPresentation = true
         accountVC.closePressed = { [weak self] in
             self?.dismiss(animated: true, completion: nil)

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -204,3 +204,10 @@ Document = "Document";
 Contact = "Contact";
 Buttons = "Buttons";
 File = "File";
+
+
+/* Suspension Screen Messages */
+
+TrialUserDisconnectionMessage = "Trial users cannot access this feature in release mode. Please upgrade your plan to continue. \nFor further assistance, contact support at support@kommunicate.io.";
+MobileNotSupportedMessage = "Your current plan does not support mobile access. \nPlease update your subscription to gain full access.";
+ChurnedUserDisconnectionMessage = "Your app provider needs to renew their subscription to enable access to messaging features.";

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -60,6 +60,13 @@ struct SystemMessage: Localizable {
         static let UpdateProfileName = localizedString(forKey: "UpdateProfileSuccessMessage")
         static let Failed = localizedString(forKey: "FailedToUpdateMessage")
     }
+    
+    enum SuspendedScreen {
+        static let ChurnedUserDisconnectionMessage = localizedString(forKey: "ChurnedUserDisconnectionMessage")
+        static let MobileNotSupportedMessage = localizedString(forKey: "MobileNotSupportedMessage")
+        static let TrialUserDisconnectionMessage = localizedString(forKey: "TrialUserDisconnectionMessage")
+
+    }
 
     enum Warning {
         static let NoEmail = localizedString(forKey: "EnterEmailMessage")

--- a/Sources/Views/StoryBoards/ALKAccountSuspensionView.xib
+++ b/Sources/Views/StoryBoards/ALKAccountSuspensionView.xib
@@ -1,28 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ALKAccountSuspensionController" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ALKAccountSuspensionController" customModule="KommunicateChatUI_iOS_SDK" customModuleProvider="target">
+            <connections>
+                <outlet property="messageLabel" destination="7rj-I8-IbZ" id="Bee-YL-z8q"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" restorationIdentifier="ALKAccountSuspensionView" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="account_suspension_icon" translatesAutoresizingMaskIntoConstraints="NO" id="DbS-he-maU">
-                    <rect key="frame" x="110" y="100" width="155" height="95"/>
+                    <rect key="frame" x="110" y="120" width="155" height="95"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="155" id="SYy-ze-OuJ"/>
                         <constraint firstAttribute="height" constant="95" id="gzT-eR-8eL"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Oh Snap!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c7s-4G-Qtz">
-                    <rect key="frame" x="137.5" y="235" width="100" height="21"/>
+                    <rect key="frame" x="137.5" y="255" width="100" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="100" id="adF-3d-ivg"/>
                         <constraint firstAttribute="height" constant="21" id="dUd-5h-Jwi"/>
@@ -32,21 +36,18 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g1O-FQ-DPW">
-                    <rect key="frame" x="161" y="276" width="53" height="5"/>
+                    <rect key="frame" x="161" y="296" width="53" height="5"/>
                     <color key="backgroundColor" red="0.80000000000000004" green="0.78431372549019607" blue="0.78431372549019607" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="5" id="ief-fM-aFI"/>
                         <constraint firstAttribute="width" constant="53" id="ure-Ve-vxD"/>
                     </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7rj-I8-IbZ">
-                    <rect key="frame" x="15" y="288" width="345" height="89"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7rj-I8-IbZ">
+                    <rect key="frame" x="15" y="308" width="345" height="89"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="89" id="Sk5-TJ-BSA"/>
                     </constraints>
-                    <string key="text">We’re sorry but messaging is not 
-available at the moment.
-Please contact support for more details</string>
                     <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="16"/>
                     <color key="textColor" red="0.45098039215686275" green="0.45098039215686275" blue="0.46274509803921571" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
- Updated the code for showing the suspension message as per the churn, trial and lite plan.
- Added the message in localized file to get multi lingual capability for this message.

## Images
<img src = 'https://github.com/user-attachments/assets/35e2a702-f14f-4882-8407-82ca7fe0c71a' height = '400'> <img src = 'https://github.com/user-attachments/assets/b7a123e2-c5b0-42ae-8faf-3173b3ec3137' height = '400'> <img src = 'https://github.com/user-attachments/assets/ca912b13-9998-4aa0-870d-c0baaea1f9bb' height = '400'>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dynamic, localized messages on the account suspension screen based on the user's subscription plan.
  - Introduced new localized messages for trial users, users without mobile access, and users with expired subscriptions.

- **Style**
  - Updated the account suspension screen layout, repositioning elements and removing hardcoded message text for improved clarity.

- **Bug Fixes**
  - Ensured the suspension screen displays the correct message for each user plan type.

- **Chores**
  - Improved localization infrastructure for easier future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->