### PR TITLE
TDH-3644: Missing localization

### DIFF
--- a/Sources/Controllers/KMChatConversationListTableViewController.swift
+++ b/Sources/Controllers/KMChatConversationListTableViewController.swift
@@ -196,7 +196,7 @@ public class KMChatConversationListTableViewController: UITableViewController, L
     }
     
     private func displayLoadingAlert(viewController: KMChatConversationListTableViewController) -> UIAlertController {
-        let alertTitle = localizedString(forKey: "WaitMessage", withDefaultValue: "Please Wait", fileName: localizedStringFileName)
+        let alertTitle = localizedString(forKey: "WaitMessage", withDefaultValue: "Please wait...", fileName: localizedStringFileName)
         
         let loadingAlertController = UIAlertController(title: alertTitle, message: nil, preferredStyle: .alert)
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Controllers/KMChatConversationViewController.swift
+++ b/Sources/Controllers/KMChatConversationViewController.swift
@@ -2338,12 +2338,20 @@ extension KMChatConversationViewController: KMChatConversationViewModelDelegate 
         let channel = channelService.getChannelByKey(channelKey)
         
         if KMCoreUserDefaultsHandler.isTeamModeEnabled(), let teamID = KMCoreUserDefaultsHandler.getAssignedTeamIds(), let teamIDArray = teamID as? [String], let newTeamID = channel?.metadata["KM_TEAM_ID"] as? String, !teamIDArray.contains(newTeamID) {
-            chatBar.textView.text = "You are restricted to type or send any message as you are no longer part of this conversation."
+            chatBar.textView.text = localizedString(
+                forKey: "ConversationRestrictedMessage",
+                withDefaultValue: "You are restricted to type or send any message as you are no longer part of this conversation.",
+                fileName: configuration.localizedStringFileName
+            )
             return true
         }
         
         if isZendeskConversation(channel: channel) {
-            chatBar.textView.text = "This chat is integrated with Zendesk Zopim. Please use Zendesk dashboard to respond and communicate with the users."
+            chatBar.textView.text = localizedString(
+                forKey: "ZendeskConversationInfoMessage",
+                withDefaultValue: "This chat is integrated with Zendesk Zopim. Please use Zendesk dashboard to respond and communicate with the users.",
+                fileName: configuration.localizedStringFileName
+            )
             return true
         }
         
@@ -2352,7 +2360,11 @@ extension KMChatConversationViewController: KMChatConversationViewModelDelegate 
            whatsappSource.contains(platformSource),
            let lastMessageTime = viewModel.getLastReceivedMessage()?.createdAtTime,
            Double(truncating: lastMessageTime) <= twentyFourHoursAgoTimeStamp() {
-            chatBar.textView.text = "The last message received from this contact was over 24 hours ago. To send Template message, go to the dashboard."
+            chatBar.textView.text = localizedString(
+                forKey: "TemplateMessageRestrictionInfo",
+                withDefaultValue: "The last message received from this contact was over 24 hours ago. To send Template message, go to the dashboard.",
+                fileName: configuration.localizedStringFileName
+            )
             return true
         } else {
             return false
@@ -2739,9 +2751,17 @@ extension KMChatConversationViewController: KMChatConversationViewModelDelegate 
             if #available(iOS 14, *) {
                 var menuItems: [UIAction] {
                    return [
-                       UIAction(title: "Rate this conversation", image: UIImage(named: "icon_favorite_active", in: Bundle.km, compatibleWith: nil), handler: { (_) in
-                           self.showFeedback()
-                       })
+                       UIAction(
+                           title: localizedString(
+                               forKey: "ConversationRatingMenuTitle",
+                               withDefaultValue: SystemMessage.Feedback.ConversationRatingMenuTitle,
+                               fileName: configuration.localizedStringFileName
+                           ),
+                           image: UIImage(named: "icon_favorite_active", in: Bundle.km, compatibleWith: nil),
+                           handler: { (_) in
+                               self.showFeedback()
+                           }
+                       )
                    ]
                 }
                 var ratingIcon = configuration.ratingMenuIcon

--- a/Sources/Controllers/KMChatMultipleLanguageSelectionViewController.swift
+++ b/Sources/Controllers/KMChatMultipleLanguageSelectionViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import KommunicateCore_iOS_SDK
 import UIKit
 
-class KMChatMultipleLanguageSelectionViewController: UIViewController {
+class KMChatMultipleLanguageSelectionViewController: UIViewController, Localizable {
     
     private var configuration: KMChatConfiguration
     private var languages: [String] = []
@@ -20,7 +20,7 @@ class KMChatMultipleLanguageSelectionViewController: UIViewController {
         let label = UILabel()
         label.font = UIFont(name: "HelveticaNeue-Bold", size: 16) ?? UIFont.systemFont(ofSize: 16)
         label.textColor = UIColor.kmDynamicColor(light: UIColor(red: 96, green: 94, blue: 94), dark: .lightText)
-        label.text = "Select a language"
+        label.text = ""
         return label
     }()
 
@@ -86,6 +86,12 @@ class KMChatMultipleLanguageSelectionViewController: UIViewController {
         languageStackView.arrangedSubviews.forEach {
             $0.removeFromSuperview()
         }
+
+        titleLabel.text = localizedString(
+            forKey: "SelectLanguageTitle",
+            withDefaultValue: "Select a language",
+            fileName: configuration.localizedStringFileName
+        )
         
         for item in self.languages {
             let view = KMLanguageView(title: item, languageList: configuration.languagesForSpeechToText)

--- a/Sources/Resources/Base.lproj/Localizable.strings
+++ b/Sources/Resources/Base.lproj/Localizable.strings
@@ -174,6 +174,18 @@ AddGroupDescriptionPlaceHolder = "Add group description";
 
 /* Feedback */
  RatingLabelTitle = "You";
+ ConversationRatingMenuTitle = "Rate this conversation";
+
+/* Conversation Restriction */
+ConversationRestrictedMessage = "You are restricted to type or send any message as you are no longer part of this conversation.";
+ZendeskConversationInfoMessage = "This chat is integrated with Zendesk Zopim. Please use Zendesk dashboard to respond and communicate with the users.";
+TemplateMessageRestrictionInfo = "The last message received from this contact was over 24 hours ago. To send Template message, go to the dashboard.";
+
+/* Misc */
+SelectLanguageTitle = "Select a language";
+ViaEmailLabel = "via email";
+SourceLabel = "Source";
+NewAttachmentLabel = "New Attachment";
 
 /* Summary UI */
  SummaryPopUpTitle = "Summary";

--- a/Sources/Utilities/SystemMessage.swift
+++ b/Sources/Utilities/SystemMessage.swift
@@ -236,6 +236,7 @@ struct SystemMessage: Localizable {
     
     enum Feedback {
         static let RatingLabelTitle = localizedString(forKey: "RatingLabelTitle")
+        static let ConversationRatingMenuTitle = localizedString(forKey: "ConversationRatingMenuTitle")
     }
     
     enum SummaryUI {

--- a/Sources/Views/KMChatEmailView.swift
+++ b/Sources/Views/KMChatEmailView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class KMChatEmailTopView: UIView {
+class KMChatEmailTopView: UIView, Localizable {
     static let height: CGFloat = 20
 
     // MARK: - Private properties
@@ -25,7 +25,7 @@ class KMChatEmailTopView: UIView {
 
     fileprivate var emailLabel: UILabel = {
         let label = UILabel()
-        label.text = "via email"
+        label.text = KMChatEmailTopView.localizedString(forKey: "ViaEmailLabel")
         label.numberOfLines = 1
         label.font = UIFont(name: "Helvetica", size: 12)
         label.isOpaque = true

--- a/Sources/Views/KMCustomCaptionViewController.swift
+++ b/Sources/Views/KMCustomCaptionViewController.swift
@@ -535,7 +535,7 @@ class KMCustomCaptionViewController: UIViewController, UICollectionViewDelegate,
     }
 }
 
-class KMImageCell: UICollectionViewCell {
+class KMImageCell: UICollectionViewCell, Localizable {
     
     let imageView: UIImageView = {
         let view = UIImageView()
@@ -577,7 +577,7 @@ class KMImageCell: UICollectionViewCell {
     
     let newAttachmentLabel: UIView = {
         let label = UILabel()
-        label.text = "New Attachment"
+        label.text = KMImageCell.localizedString(forKey: "NewAttachmentLabel")
         label.font = .systemFont(ofSize: 14)
         label.textColor =  UIColor.kmDynamicColor(light: UIColor.text(.white), dark: UIColor.text(.grayCC))
         label.isHidden = true

--- a/Sources/Views/KMFriendSourceURLViewCell.swift
+++ b/Sources/Views/KMFriendSourceURLViewCell.swift
@@ -125,7 +125,7 @@ open class KMFriendSourceURLViewCell: KMChatMessageCell {
     private var sourceLabel: UILabel = {
         let label = UILabel()
         label.textColor = UIColor(netHex: 0x313131)
-        label.text = "Source"
+        label.text = KMFriendSourceURLViewCell.localizedString(forKey: "SourceLabel")
         label.font = UIFont.boldSystemFont(ofSize: 14)
         return label
     }()


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adding Missing localization Strings.
```
• [KMChatConversationViewController.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Controllers/KMChatConversationViewController.swift#L2341)
"​You are restricted to type or send any message as you are no longer part of this conversation."
• [KMChatConversationViewController.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Controllers/KMChatConversationViewController.swift#L2346)
"​This chat is integrated with ​Zendesk ​Zopim. ​Please use ​Zendesk dashboard to respond and communicate with the users."
• [KMChatConversationViewController.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Controllers/KMChatConversationViewController.swift#L2355)
"​The last message received from this contact was over 24 hours ago. ​To send ​Template message, go to the dashboard."
• [KMChatMultipleLanguageSelectionViewController.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Controllers/KMChatMultipleLanguageSelectionViewController.swift#L23)
"​Select a language"
• [KMChatEmailView.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Views/KMChatEmailView.swift#L28)
"via email"
• [KMFriendSourceURLViewCell.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Views/KMFriendSourceURLViewCell.swift#L128)
"​Source"
• [KMCustomCaptionViewController.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/KommunicateChatUI-iOS-SDK/Complete/Views/KMCustomCaptionViewController.swift#L580)
"​New ​Attachment"
• [CustomPreChatFormView.swift](https://github.com/Users/kommunicate/Documents/Code/Kommunicate-iOS-SDK/Example/Pods/Development%20Pods/Kommunicate/Views/CustomPreChatFormView.swift#L50)
"​Pre​-​Chat ​Lead ​Collection"
```
## Motivation
<!-- Why are you making this change? -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->