### PR TITLE
TDH-3799: Calculating Height Based On Elements Count

### DIFF
--- a/Sources/Views/KMChatGenericCardCell.swift
+++ b/Sources/Views/KMChatGenericCardCell.swift
@@ -142,8 +142,6 @@ open class KMChatGenericCardCell: UICollectionViewCell {
         case buttonsView
     }
 
-    let maxButtonCount = 8
-
     lazy var coverImageHeight = self.coverImageView.heightAnchor.constraint(equalToConstant: Config.imageHeight)
 
     open var coverImageView: UIImageView = {
@@ -275,8 +273,8 @@ open class KMChatGenericCardCell: UICollectionViewCell {
         var stackViewSpacing = (Config.spacing * 2)
         stackViewSpacing += (card.buttons != nil) ? Config.spacing : 0
         stackViewSpacing += (card.description != nil) ? Config.spacing : 0
-        if let count = card.buttons?.count {
-            stackViewSpacing += CGFloat(count) - Config.buttonStackViewSpacing // 1 space between 2 buttons.
+        if let count = card.buttons?.count, count > 1 {
+            stackViewSpacing += CGFloat(count - 1) * Config.buttonStackViewSpacing
         }
 
         return headerHt + titleHeight + subtitleHeight + descriptionHeight + totalButtonHeight + CGFloat(stackViewSpacing)
@@ -388,26 +386,44 @@ open class KMChatGenericCardCell: UICollectionViewCell {
 
     private func updateViewFor(_ buttons: [KMCardTemplate.Button]?) {
         guard let buttons = buttons else { return }
-        // Hide extra buttons
+        ensureActionButtonCount(buttons.count)
         actionButtons.enumerated().forEach {
             if $0 >= buttons.count { $1.isHidden = true } else { $1.isHidden = false; $1.setTitle(buttons[$0].name, for: .normal) }
         }
-        let count = CGFloat(min(buttons.count, actionButtons.count))
-        buttonStackView.constraint(withIdentifier: ConstraintIdentifier.buttonsView.rawValue)?.constant = count * Config.buttonHeight
+        buttonStackView.constraint(withIdentifier: ConstraintIdentifier.buttonsView.rawValue)?.constant = Self.buttonsHeight(count: buttons.count)
     }
 
     private func setUpButtons() {
-        let style = CardStyle.shared
-        actionButtons = (0 ..< maxButtonCount).map {
-            let button = UIButton()
-            button.setTitleColor(style.actionButton.textColor, for: .normal)
-            button.setFont(font: Font.button)
-            button.setTitle("Button", for: .normal)
-            button.addTarget(self, action: #selector(buttonSelected(_:)), for: .touchUpInside)
-            button.tag = $0
-            button.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
-            return button
+        actionButtons = (0 ..< 8).map { makeActionButton(index: $0) }
+    }
+
+    private func ensureActionButtonCount(_ count: Int) {
+        guard count > actionButtons.count else { return }
+        for index in actionButtons.count ..< count {
+            let button = makeActionButton(index: index)
+            actionButtons.append(button)
+            buttonStackView.addArrangedSubview(button)
+            button.heightAnchor.constraint(equalToConstant: Config.buttonHeight).isActive = true
         }
+    }
+
+    private func makeActionButton(index: Int) -> UIButton {
+        let style = CardStyle.shared
+        let button = UIButton()
+        button.setTitleColor(style.actionButton.textColor, for: .normal)
+        button.setFont(font: Font.button)
+        button.setTitle("Button", for: .normal)
+        button.addTarget(self, action: #selector(buttonSelected(_:)), for: .touchUpInside)
+        button.tag = index
+        button.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        return button
+    }
+
+    private class func buttonsHeight(count: Int) -> CGFloat {
+        guard count > 0 else { return 0 }
+        let buttonHeight = CGFloat(count) * Config.buttonHeight
+        let separatorHeight = CGFloat(count - 1) * Config.buttonStackViewSpacing
+        return buttonHeight + separatorHeight
     }
 
     private func setupConstraints() {

--- a/Sources/Views/KMChatGenericCardCell.swift
+++ b/Sources/Views/KMChatGenericCardCell.swift
@@ -268,14 +268,11 @@ open class KMChatGenericCardCell: UICollectionViewCell {
         let descriptionConstraint = CGSize(width: maxWidth, height: Font.description.lineHeight)
         let descriptionHeight = textHeight(card.description, size: descriptionConstraint, font: Font.description) * CGFloat(KMChatGenericCardCell.Config.descriptionMaxLines)
 
-        let totalButtonHeight = Config.buttonHeight * CGFloat(card.buttons?.count ?? 0)
+        let totalButtonHeight = buttonsHeight(count: card.buttons?.count ?? 0)
 
         var stackViewSpacing = (Config.spacing * 2)
         stackViewSpacing += (card.buttons != nil) ? Config.spacing : 0
         stackViewSpacing += (card.description != nil) ? Config.spacing : 0
-        if let count = card.buttons?.count, count > 1 {
-            stackViewSpacing += CGFloat(count - 1) * Config.buttonStackViewSpacing
-        }
 
         return headerHt + titleHeight + subtitleHeight + descriptionHeight + totalButtonHeight + CGFloat(stackViewSpacing)
     }
@@ -294,7 +291,7 @@ open class KMChatGenericCardCell: UICollectionViewCell {
         setCoverImage(card.header)
         contentView.layoutIfNeeded()
         guard let buttons = card.buttons, !buttons.isEmpty else {
-            buttonStackView.isHidden = true
+            resetButtons()
             return
         }
         buttonStackView.isHidden = false
@@ -391,6 +388,12 @@ open class KMChatGenericCardCell: UICollectionViewCell {
             if $0 >= buttons.count { $1.isHidden = true } else { $1.isHidden = false; $1.setTitle(buttons[$0].name, for: .normal) }
         }
         buttonStackView.constraint(withIdentifier: ConstraintIdentifier.buttonsView.rawValue)?.constant = Self.buttonsHeight(count: buttons.count)
+    }
+
+    private func resetButtons() {
+        actionButtons.forEach { $0.isHidden = true }
+        buttonStackView.constraint(withIdentifier: ConstraintIdentifier.buttonsView.rawValue)?.constant = 0
+        buttonStackView.isHidden = true
     }
 
     private func setUpButtons() {

--- a/Sources/Views/KMListTemplateView.swift
+++ b/Sources/Views/KMListTemplateView.swift
@@ -211,9 +211,7 @@ class ListTemplateView: UIView {
             actionButtons.enumerated().forEach { $1.isHidden = true }
             return
         }
-        if buttons.count > actionButtons.count {
-            print("Number of buttons are >8. Only first 8 will be shown")
-        }
+        ensureActionButtonCount(buttons.count)
         actionButtons.enumerated().forEach {
             if $0 >= buttons.count { $1.isHidden = true } else {
                 $1.isHidden = false
@@ -227,9 +225,7 @@ class ListTemplateView: UIView {
             listItems.enumerated().forEach { $1.isHidden = true }
             return
         }
-        if elements.count > listItems.count {
-            print("Number of elements are >8. Only first 8 will be shown")
-        }
+        ensureListItemCount(elements.count)
         listItems.enumerated().forEach {
             if $0 >= elements.count { $1.isHidden = true } else {
                 $1.isHidden = false
@@ -250,11 +246,11 @@ class ListTemplateView: UIView {
         var height: CGFloat = 0
         height += template.headerImgSrc != nil ? imageHeight : CGFloat(0)
         height += template.headerText != nil ? textHeight : CGFloat(0)
-        let elementCount = min(8, template.elements?.count ?? 0)
+        let elementCount = template.elements?.count ?? 0
         height += CGFloat(elementCount) * KMListTemplateElementView.height()
-        let buttonCount = min(8, template.buttons?.count ?? 0)
+        let buttonCount = template.buttons?.count ?? 0
         height += CGFloat(buttonCount) * buttonHeight
-        let spacing = min(8, template.elements?.count ?? 0) + min(8, template.buttons?.count ?? 0)
+        let spacing = elementCount + buttonCount
         return height + CGFloat(spacing)
     }
 
@@ -272,33 +268,57 @@ class ListTemplateView: UIView {
     }
 
     private func setupButtons() {
-        let buttonTextColor = listStyle.actionButton.text
-        let buttonBackgroundColor = listStyle.actionButton.background
-        actionButtons = (0 ... 7).map {
-            let button = UIButton()
-            button.setTitleColor(buttonTextColor, for: .normal)
-            button.setFont(font: UIFont.font(.bold(size: 15.0)))
-            button.setTitle("Button", for: .normal)
-            button.addTarget(self, action: #selector(buttonSelected(_:)), for: .touchUpInside)
-            button.titleLabel?.numberOfLines = 1
-            button.tag = $0
-            button.backgroundColor = .kmDynamicColor(light: buttonBackgroundColor, dark: UIColor.appBarDarkColor())
-            button.layoutIfNeeded()
-            return button
-        }
+        actionButtons = (0 ... 7).map { makeActionButton(index: $0) }
     }
 
     private func setupElements() {
-        listItems = (0 ... 7).map {
-            let item = KMListTemplateElementView()
-            item.tag = $0
-            item.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
-            item.selected = { [weak self] element in
-                guard let weakSelf = self, let selected = weakSelf.selected else { return }
-                selected(element, nil, element.action)
-            }
-            return item
+        listItems = (0 ... 7).map { makeListItem(index: $0) }
+    }
+
+    private func ensureActionButtonCount(_ count: Int) {
+        guard count > actionButtons.count else { return }
+        for index in actionButtons.count ..< count {
+            let button = makeActionButton(index: index)
+            actionButtons.append(button)
+            buttonStackView.addArrangedSubview(button)
+            button.heightAnchor.constraint(equalToConstant: ListTemplateView.buttonHeight).isActive = true
         }
+    }
+
+    private func ensureListItemCount(_ count: Int) {
+        guard count > listItems.count else { return }
+        for index in listItems.count ..< count {
+            let item = makeListItem(index: index)
+            listItems.append(item)
+            elementStackView.addArrangedSubview(item)
+            item.heightAnchor.constraint(equalToConstant: KMListTemplateElementView.height()).isActive = true
+        }
+    }
+
+    private func makeActionButton(index: Int) -> UIButton {
+        let buttonTextColor = listStyle.actionButton.text
+        let buttonBackgroundColor = listStyle.actionButton.background
+        let button = UIButton()
+        button.setTitleColor(buttonTextColor, for: .normal)
+        button.setFont(font: UIFont.font(.bold(size: 15.0)))
+        button.setTitle("Button", for: .normal)
+        button.addTarget(self, action: #selector(buttonSelected(_:)), for: .touchUpInside)
+        button.titleLabel?.numberOfLines = 1
+        button.tag = index
+        button.backgroundColor = .kmDynamicColor(light: buttonBackgroundColor, dark: UIColor.appBarDarkColor())
+        button.layoutIfNeeded()
+        return button
+    }
+
+    private func makeListItem(index: Int) -> KMListTemplateElementView {
+        let item = KMListTemplateElementView()
+        item.tag = index
+        item.backgroundColor = .kmDynamicColor(light: .white, dark: UIColor.appBarDarkColor())
+        item.selected = { [weak self] element in
+            guard let weakSelf = self, let selected = weakSelf.selected else { return }
+            selected(element, nil, element.action)
+        }
+        return item
     }
 
     private func setupConstraints() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
PR Description
Fix rich message card and list template rendering issues in Kommunicate​Chat​UI​-i​OS​-​SDK.

Changes
• Fixed generic card button stack height calculation to include separator spacing between buttons.
• Removed the fixed 8-button cap in generic card rendering by creating action buttons dynamically from payload count.
• Removed the fixed 8-item cap in list template rendering by creating list item/action button views dynamically.
• Updated list template row height calculation to use actual payload counts instead of min(8, ...).

Why
Cards with many action buttons could render the final button/bottom border incorrectly because separator spacing was included in row height but not in the button stack height constraint. List templates also silently capped items/buttons at 8.

Validation
• Verified the rich message card border issue is fixed in the example app.
• Ran Xcode diagnostics for the touched ChatUI files; no issues found.

Before Fix:

<img width="302" height="512" alt="Screenshot 2026-05-20 at 5 02 50 PM" src="https://github.com/user-attachments/assets/c7c5c64c-2803-469c-9110-75bb04f596c4" />

After Fix:

<img width="335" height="754" alt="Screenshot 2026-05-20 at 8 13 53 PM" src="https://github.com/user-attachments/assets/064cc599-1405-4a62-bf74-b313f5bc270c" />



## Motivation
<!-- Why are you making this change? -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->